### PR TITLE
Record Stats for Processed Jobs (Succeeded and Failed)

### DIFF
--- a/lib/exq.ex
+++ b/lib/exq.ex
@@ -5,7 +5,7 @@ defmodule Exq do
   end
 
   def start_link(opts \\ []) do
-    :gen_server.start_link(Exq.Manager, opts, [])
+    {:ok, pid} = :gen_server.start_link(Exq.Manager, opts, [])
   end
 
   def stop(pid) do
@@ -14,6 +14,14 @@ defmodule Exq do
 
   def enqueue(pid, queue, worker, args) do 
     :gen_server.call(pid, {:enqueue, queue, worker, args})
+  end
+
+  def find_error(pid, jid) do
+    :gen_server.call(pid, {:find_error, jid})
+  end
+
+  def find_job(pid, queue, jid) do
+    :gen_server.call(pid, {:find_job, queue, jid})
   end
 
 end

--- a/lib/exq/failed_job.ex
+++ b/lib/exq/failed_job.ex
@@ -1,0 +1,3 @@
+defmodule Exq.FailedJob do
+  defstruct args: nil, class: "ExqGenericError", error_message: nil, error_class: nil, failed_at: nil, queue: nil, retry: false, retried_at: nil, retry_count: nil, jid: nil, fid: nil
+end

--- a/lib/exq/job.ex
+++ b/lib/exq/job.ex
@@ -1,0 +1,3 @@
+defmodule Exq.Job do
+  defstruct queue: nil, class: nil, args: nil, jid: nil, finished_at: nil, enqueued_at: nil
+end

--- a/lib/exq/redis.ex
+++ b/lib/exq/redis.ex
@@ -4,10 +4,29 @@ defmodule Exq.Redis do
     {:ok, res} = :eredis.q(redis, [:flushdb])
     res
   end
+
+  def incr!(redis, key) do
+    {:ok, count} = :eredis.q(redis, ["INCR", key])
+    count
+  end
+
+  def get!(redis, key) do
+    {:ok, val} = :eredis.q(redis, ["GET", key])
+    val
+  end
+
+  def set!(redis, key, val \\ 0) do
+    :eredis.q(redis, ["SET", key, val])
+  end
   
   def smembers!(redis, set) do 
     {:ok, members} = :eredis.q(redis, ["SMEMBERS", set])
     members
+  end
+
+ def lrange!(redis, list, range_start \\ "0", range_end \\ "-1") do
+    {:ok, items} = :eredis.q(redis, ["LRANGE", list, range_start, range_end])
+    items
   end
 
   def sadd!(redis, set, member) do 

--- a/lib/exq/stats.ex
+++ b/lib/exq/stats.ex
@@ -1,0 +1,46 @@
+defmodule Exq.Stats do
+  use Timex
+
+  def record_processed(redis, namespace, job) do
+    pjob = Poison.decode!(job, as: Exq.Job)
+    count = Exq.Redis.incr!(redis, Exq.RedisQueue.full_key(namespace, "stat:processed"))
+    date = DateFormat.format!(Date.local, "%Y-%m-%d", :strftime)
+    Exq.Redis.incr!(redis, Exq.RedisQueue.full_key(namespace, "stat:processed:#{date}"))
+    {:ok, count}
+  end
+
+  def record_failure(redis, namespace, error, job) do
+
+    fid = UUID.uuid4
+    failed_at = DateFormat.format!(Date.local, "{ISO}")
+
+    job = Poison.decode!(job, as: Exq.Job)
+    failed_job = %Exq.FailedJob{args: job.args, class: job.class, error_message: error, failed_at: failed_at, jid: job.jid, queue: job.queue, fid: fid}
+
+    fjob = Poison.encode!(failed_job, %{})
+    Exq.Redis.rpush!(redis, Exq.RedisQueue.full_key(namespace, "stat:failed"), fjob)
+    date = DateFormat.format!(Date.local, "%Y-%m-%d", :strftime)
+    Exq.Redis.rpush!(redis, Exq.RedisQueue.full_key(namespace, "stat:failed:#{date}"), fjob)
+    {:ok, job.jid}
+  end
+
+  def find_error(redis, namespace, jid) do
+    errors = Exq.Redis.lrange!(redis, Exq.RedisQueue.full_key(namespace, "stat:failed"))
+
+    finder = fn({j, idx}) -> 
+      job = Poison.decode!(j, as: Exq.FailedJob)
+      job.jid == jid
+    end
+
+    error = Enum.find(Enum.with_index(errors), finder)
+   
+    case error do
+      nil ->
+        {:not_found, nil}
+      _ ->
+        {job, idx} = error
+        {:ok, job, idx}
+    end
+  end
+end
+  

--- a/mix.exs
+++ b/mix.exs
@@ -19,9 +19,10 @@ defmodule Exq.Mixfile do
   # { :foobar, "0.1", git: "https://github.com/elixir-lang/foobar.git" }
   defp deps do
     [
-      { :uuid, "~> 0.1.5", github: 'zyro/elixir-uuid'},
+      { :uuid, "~> 0.1.5", github: 'zyro/elixir-uuid' },
       { :eredis, github: 'wooga/eredis', tag: 'v1.0.5' },
-      { :jsex, "2.0.0"}
+      { :poison, "~> 1.2.0"},
+      { :timex, "~> 0.13.0" }
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"elixir_uuid": {:git, "git://github.com/zyro/elixir-uuid.git", "7ffaa6df3fda51e52d293bebfb717bc859cfdb7f", []},
   "eredis": {:git, "git://github.com/wooga/eredis.git", "a2273335de773209fd3ab30542fd1b670ca5c957", [tag: 'v1.0.5']},
-  "jsex": {:hex, :jsex, "2.0.0"},
-  "jsx": {:hex, :jsx, "2.0.3"},
+  "poison": {:hex, :poison, "1.2.0"},
+  "timex": {:hex, :timex, "0.13.0"},
   "uuid": {:git, "git://github.com/zyro/elixir-uuid.git", "7ffaa6df3fda51e52d293bebfb717bc859cfdb7f", []}}

--- a/test/redis_queue_test.exs
+++ b/test/redis_queue_test.exs
@@ -5,7 +5,6 @@ defmodule Exq.RedisQueueTest do
 
   setup_all do
     TestRedis.setup
-    IO.puts "Start"
     on_exit fn ->
       TestRedis.teardown
     end
@@ -32,8 +31,8 @@ defmodule Exq.RedisQueueTest do
     assert jid != nil
 
     job_str = Exq.RedisQueue.dequeue(:testredis, "test", "default")
-    job = JSEX.decode!(job_str)
-    assert Dict.get(job, "jid") == jid
+    job = Poison.decode!(job_str, as: Exq.Job)
+    assert job.jid == jid
   end
 
 end

--- a/test/redis_test.exs
+++ b/test/redis_test.exs
@@ -5,7 +5,6 @@ defmodule Exq.RedisTest do
 
   setup_all do 
     TestRedis.setup
-    IO.puts "Start"
     on_exit fn ->
       TestRedis.teardown
     end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,10 @@
+defmodule TestStats do
+  def processed_count(redis, namespace) do
+    count = Exq.Redis.get!(redis, Exq.RedisQueue.full_key(namespace, "stat:processed"))
+    {:ok, count}
+  end
+end
+
 defmodule TestRedis do 
   #TODO: Automate config
   def start do 

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -56,4 +56,7 @@ defmodule WorkerTest do
       "{ \"queue\": \"default\", \"class\": \"WorkerTest/nonexist\", \"args\": [] }")
     assert_terminate(worker, false)
   end
+
+
+
 end


### PR DESCRIPTION
i think this a good way to store failures, we keep the whole original job. Ive also added functionality to find jobs and errors in queues. This will be useful for finding and manually retrying from the web ui. Next we should look at how to auto-retry jobs.

any thoughts or feed back is welcome as always.

Closes #9, #23, #20  
