### PR TITLE
Use mix config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,3 +2,9 @@ use Mix.Config
 
 config :logger, :console,
   format: "\n$date $time [$level]: $message \n"
+
+config :exq,
+  host: '127.0.0.1',
+  port: 6379,
+  namespace: "exq",
+  queues: ["default"]

--- a/lib/exq/config.ex
+++ b/lib/exq/config.ex
@@ -1,0 +1,5 @@
+defmodule Exq.Config do
+  def get(key, fallback \\ nil) do
+    Application.get_env(:exq, key, fallback)
+  end
+end

--- a/lib/exq/manager.ex
+++ b/lib/exq/manager.ex
@@ -11,15 +11,18 @@ defmodule Exq.Manager do
 ## gen server callbacks
 ##===========================================================
 
-  def init(opts) do
-    host = Keyword.get(opts, :host, '127.0.0.1')
-    port = Keyword.get(opts, :port, 6379)
-    database = Keyword.get(opts, :database, 0)
-    password = Keyword.get(opts, :password, '')
-    queues = Keyword.get(opts, :queues, ["default"])
-    namespace = Keyword.get(opts, :namespace, "resque")
-    reconnect_on_sleep = Keyword.get(opts, :reconnect_on_sleep, 100)
-    poll_timeout = Keyword.get(opts, :poll_timeout, 50)
+
+  def init(opts) do 
+
+    host = Keyword.get(opts, :host, Exq.Config.get(:host, '127.0.0.1')) 
+    port = Keyword.get(opts, :port, Exq.Config.get(:port, 6379)) 
+    database = Keyword.get(opts, :database, Exq.Config.get(:database, 0))
+    password = Keyword.get(opts, :password, Exq.Config.get(:password, '')) 
+    queues = Keyword.get(opts, :queues, Exq.Config.get(:queues, ["default"])) 
+    namespace = Keyword.get(opts, :namespace, Exq.Config.get(:namespace, "exq"))
+    poll_timeout = Keyword.get(opts, :poll_timeout, Exq.Config.get(:poll_timeout, 50))
+    reconnect_on_sleep = Keyword.get(opts, :reconnect_on_sleep, Exq.Config.get(:reconnect_on_sleep, 100))
+
     {:ok, redis} = :eredis.start_link(host, port, database, password, reconnect_on_sleep)
     state = %State{redis: redis,
                       busy_workers: [],

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -1,0 +1,12 @@
+Code.require_file "test_helper.exs", __DIR__
+defmodule Exq.ConfigTest do
+  use ExUnit.Case
+  require Mix.Config
+
+  test "Mix.Config should change the host." do
+    assert Exq.Config.get(:host) == '127.0.0.1'
+    Mix.Config.persist([exq: [host: '127.1.1.1']])
+    assert Exq.Config.get(:host) == '127.1.1.1'
+  end
+
+end


### PR DESCRIPTION
- Add defaults to the exq application mix config, bundled with exq.
- A parent can overwrite settings for the exq app in it's own config
- Continues to allow for config values to overwrite mix config values
- Add a wrapper to easily pull Exq config variables.

Closes #13 
