### PR TITLE
Allow throttling for number of concurrent workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,14 @@ Then run ```mix deps.get```.
 
 By default, Exq will use configuration from your config.exs file.  You can use this
 to configure your Redis host, port, as well as namespace (which helps isolate the data in Redis).
+The "concurrency" setting will let you configure the amount of concurrent workers that will be allowed, or :infinite to disable any throttling.
 
 ```elixir
 config :exq,
   host: '127.0.0.1',
   port: 6379,
   namespace: "exq",
+  concurrency: :infinite,
   queues: ["default"]
 ```
 

--- a/lib/exq/manager.ex
+++ b/lib/exq/manager.ex
@@ -6,14 +6,23 @@ defmodule Exq.Manager do
   @default_name :exq
 
   defmodule State do
-    defstruct pid: nil, host: nil, redis: nil, namespace: nil, busy_workers: 0,
-              concurrency: :infinite, queues: nil, poll_timeout: nil, stats: nil, enqueuer: nil
+    defstruct pid: nil, host: nil, redis: nil, namespace: nil, work_table: nil,
+              concurrency: nil, queues: nil, poll_timeout: nil, stats: nil, enqueuer: nil
   end
 
   def start_link(opts \\ []) do
     name = Keyword.get(opts, :name, @default_name)
     GenServer.start_link(__MODULE__, [opts], [{:name, name}])
   end
+
+  def update_worker_count(work_table, queue, delta) do
+    worker_count = case :ets.lookup(work_table, queue) do
+      [{_, worker_count}] -> worker_count
+      [] -> 0
+    end
+    :ets.insert(work_table, {queue, worker_count + delta})
+  end
+
 
 ##===========================================================
 ## gen server callbacks
@@ -23,9 +32,13 @@ defmodule Exq.Manager do
     {:ok, redis} = Exq.Redis.connection(opts)
     name = Keyword.get(opts, :name, @default_name)
     queues = Keyword.get(opts, :queues, Exq.Config.get(:queues, ["default"]))
+    work_table = :ets.new(:work_table, [:set, :public])
+    Enum.each(queues, fn (queue) ->
+      :ets.insert(work_table, {queue, 0})
+    end)
     namespace = Keyword.get(opts, :namespace, Exq.Config.get(:namespace, "exq"))
     poll_timeout = Keyword.get(opts, :poll_timeout, Exq.Config.get(:poll_timeout, 50))
-    concurrency = Keyword.get(opts, :concurrency, Exq.Config.get(:concurrency, :infinite))
+    concurrency = Keyword.get(opts, :concurrency, Exq.Config.get(:concurrency, 10_000))
     {:ok, localhost} = :inet.gethostname()
 
     {:ok, stats} =  GenServer.start_link(Exq.Stats, {redis}, [])
@@ -37,7 +50,7 @@ defmodule Exq.Manager do
       namespace: namespace)
 
     state = %State{redis: redis,
-                      busy_workers: 0,
+                      work_table: work_table,
                       concurrency: concurrency,
                       enqueuer: enq,
                       host:  to_string(localhost),
@@ -55,11 +68,9 @@ defmodule Exq.Manager do
     {:noreply, state, 10}
   end
 
-
-
   def handle_cast({:worker_terminated, pid}, state) do
     GenServer.cast(state.stats, {:process_terminated, state.namespace, state.host, pid})
-    {:noreply, %{state | busy_workers: state.busy_workers - 1}, 0}
+    {:noreply, state, 0}
   end
 
   def handle_cast({:success, job}, state) do
@@ -105,31 +116,36 @@ defmodule Exq.Manager do
 ## Internal Functions
 ##===========================================================
 
-  def dequeue_and_dispatch(state) do
-    if state.concurrency == :infinite || state.concurrency > state.busy_workers do
-      case dequeue(state.redis, state.namespace, state.queues) do
-        {:none, _}   -> {state, state.poll_timeout}
-        {job, queue} -> {dispatch_job(state, job), 0}
-      end
-    else
-      {state, state.poll_timeout}
+  def dequeue_and_dispatch(state), do: dequeue_and_dispatch(state, available_queues(state))
+  def dequeue_and_dispatch(state, []), do: {state, state.poll_timeout}
+  def dequeue_and_dispatch(state, queues) do
+    case Exq.RedisQueue.dequeue(state.redis, state.namespace, queues) do
+      {:none, _}   -> {state, state.poll_timeout}
+      {job, queue} -> {dispatch_job(state, job, queue), 0}
     end
   end
 
-  def dequeue(redis, namespace, queues) do
-    Exq.RedisQueue.dequeue(redis, namespace, queues)
+  def available_queues(state) do
+    if state.concurrency == :infinite do
+      state.queues
+    else
+      Enum.filter(state.queues, fn(q) ->
+        [{_, worker_count}] = :ets.lookup(state.work_table, q)
+        worker_count < state.concurrency
+      end)
+    end
   end
 
-  def dispatch_job(state, job) do
-    {:ok, worker} = Exq.Worker.start(job, state.pid)
-    GenServer.cast(state.stats, {:add_process, state.namespace, %Exq.Process{pid: worker, host: state.host, job: job, started_at: DateFormat.format!(Date.local, "{ISO}")}})
+  def dispatch_job(state, job, queue) do
+    {:ok, worker} = Exq.Worker.start(job, state.pid, queue, state.work_table)
+    Exq.Stats.add_process(state.stats, state.namespace, worker, state.host, job)
     Exq.Worker.work(worker)
-    %{state | busy_workers: state.busy_workers + 1}
+    update_worker_count(state.work_table, queue, 1)
+    state
   end
 
   def default_name, do: @default_name
 
   def stop(pid) do
   end
-
 end

--- a/lib/exq/manager.ex
+++ b/lib/exq/manager.ex
@@ -108,8 +108,8 @@ defmodule Exq.Manager do
   def dequeue_and_dispatch(state) do
     if state.concurrency == :infinite || state.concurrency > state.busy_workers do
       case dequeue(state.redis, state.namespace, state.queues) do
-        :none -> {state, state.poll_timeout}
-        job -> {dispatch_job(state, job), 0}
+        {:none, _}   -> {state, state.poll_timeout}
+        {job, queue} -> {dispatch_job(state, job), 0}
       end
     else
       {state, state.poll_timeout}

--- a/lib/exq/redis_queue.ex
+++ b/lib/exq/redis_queue.ex
@@ -34,7 +34,7 @@ defmodule Exq.RedisQueue do
     dequeue_random(redis, namespace, queues)
   end
   def dequeue(redis, namespace, queue) do
-    Exq.Redis.lpop!(redis, queue_key(namespace, queue))
+    {Exq.Redis.lpop!(redis, queue_key(namespace, queue)), queue}
   end
 
   def full_key("", key), do: key
@@ -48,13 +48,13 @@ defmodule Exq.RedisQueue do
   end
 
   defp dequeue_random(redis, namespace, []) do
-    nil
+    {nil, nil}
   end
   defp dequeue_random(redis, namespace, queues) do
     [h | rq]  = Exq.Shuffle.shuffle(queues)
     case dequeue(redis, namespace, h) do
-      nil -> dequeue_random(redis, namespace, rq)
-      job -> job
+      {nil, _} -> dequeue_random(redis, namespace, rq)
+      {job, q} -> {job, q}
     end
   end
 

--- a/lib/exq/stats.ex
+++ b/lib/exq/stats.ex
@@ -7,6 +7,10 @@ defmodule Exq.Stats do
     defstruct redis: nil
   end
 
+  def add_process(pid, namespace, worker, host, job) do
+    GenServer.cast(pid, {:add_process, namespace, %Exq.Process{pid: worker, host: host, job: job, started_at: DateFormat.format!(Date.local, "{ISO}")}})
+  end
+
 ##===========================================================
 ## gen server callbacks
 ##===========================================================

--- a/lib/exq/worker.ex
+++ b/lib/exq/worker.ex
@@ -3,11 +3,11 @@ defmodule Exq.Worker do
   use GenServer
 
   defmodule State do
-    defstruct job: nil, manager: nil
+    defstruct job: nil, manager: nil, queue: nil, work_table: nil
   end
 
-  def start(job, manager \\ nil) do
-    GenServer.start(__MODULE__, {job, manager}, [])
+  def start(job, manager, queue, work_table) do
+    GenServer.start(__MODULE__, {job, manager, queue, work_table}, [])
   end
 
   def work(pid) do
@@ -18,8 +18,8 @@ defmodule Exq.Worker do
 ## gen server callbacks
 ##===========================================================
 
-  def init({job, manager}) do
-    {:ok, %State{job: job, manager: manager}}
+  def init({job, manager, queue, work_table}) do
+    {:ok, %State{job: job, manager: manager, queue: queue, work_table: work_table}}
   end
 
   def handle_cast(:work, state) do
@@ -47,6 +47,7 @@ defmodule Exq.Worker do
       true ->
         GenServer.cast(state.manager, {:worker_terminated, self()})
         GenServer.cast(state.manager, {:success, state.job})
+        Exq.Manager.update_worker_count(state.work_table, state.queue, -1)
       _ ->
         Logger.error("Worker terminated, but manager was not alive.")
     end
@@ -61,6 +62,7 @@ defmodule Exq.Worker do
         GenServer.cast(state.manager, {:worker_terminated, self()})
         error_msg = Inspect.Algebra.format(Inspect.Algebra.to_doc(error, %Inspect.Opts{}), %Inspect.Opts{}.width)
         GenServer.cast(state.manager, {:failure, to_string(error_msg), state.job})
+        Exq.Manager.update_worker_count(state.work_table, state.queue, -1)
       _ ->
         Logger.error("Worker terminated, but manager was not alive.")
     end

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -17,6 +17,13 @@ defmodule ExqTest do
     end
   end
 
+  defmodule SleepWorker do
+    def perform(time, message) do
+      :timer.sleep(time)
+      send :exqtest, {message}
+    end
+  end
+
   defmodule CustomMethodWorker do
     def simple_perform do
     end
@@ -87,6 +94,19 @@ defmodule ExqTest do
     wait_long
     assert_received {:worked, 1}
     assert_received {:worked, 2}
+    stop_process(sup)
+  end
+
+  test "throttle workers" do
+    Process.register(self, :exqtest)
+    {:ok, sup} = Exq.start_link([name: :exq_t, port: 6555, namespace: "test", concurrency: 1])
+    {:ok, _} = Exq.enqueue(:exq_t, "default", "ExqTest.SleepWorker", [40, :worked])
+    {:ok, _} = Exq.enqueue(:exq_t, "default", "ExqTest.SleepWorker", [40, :worked2])
+    {:ok, _} = Exq.enqueue(:exq_t, "default", "ExqTest.SleepWorker", [100, :finished])
+    :timer.sleep(120)
+    assert_received {"worked"}
+    assert_received {"worked2"}
+    refute_received {"finished"}
     stop_process(sup)
   end
 

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -97,16 +97,21 @@ defmodule ExqTest do
     stop_process(sup)
   end
 
-  test "throttle workers" do
+  test "throttle workers per queue" do
     Process.register(self, :exqtest)
-    {:ok, sup} = Exq.start_link([name: :exq_t, port: 6555, namespace: "test", concurrency: 1])
-    {:ok, _} = Exq.enqueue(:exq_t, "default", "ExqTest.SleepWorker", [40, :worked])
-    {:ok, _} = Exq.enqueue(:exq_t, "default", "ExqTest.SleepWorker", [40, :worked2])
-    {:ok, _} = Exq.enqueue(:exq_t, "default", "ExqTest.SleepWorker", [100, :finished])
+    {:ok, sup} = Exq.start_link([name: :exq_t, port: 6555, namespace: "test", concurrency: 1, queues: ["q1", "q2"]])
+    {:ok, _} = Exq.enqueue(:exq_t, "q1", "ExqTest.SleepWorker", [40, :worked])
+    {:ok, _} = Exq.enqueue(:exq_t, "q1", "ExqTest.SleepWorker", [40, :worked2])
+    {:ok, _} = Exq.enqueue(:exq_t, "q1", "ExqTest.SleepWorker", [100, :finished])
+    # q2 should be clear
+    {:ok, _} = Exq.enqueue(:exq_t, "q2", "ExqTest.SleepWorker", [100, :q2_finished])
+
     :timer.sleep(120)
+
     assert_received {"worked"}
     assert_received {"worked2"}
     refute_received {"finished"}
+    assert_received {"q2_finished"}
     stop_process(sup)
   end
 

--- a/test/redis_queue_test.exs
+++ b/test/redis_queue_test.exs
@@ -13,17 +13,18 @@ defmodule Exq.RedisQueueTest do
 
   test "enqueue/dequeue single queue" do
     Exq.RedisQueue.enqueue(:testredis, "test", "default", "MyWorker", [])
-    deq = Exq.RedisQueue.dequeue(:testredis, "test", "default")
+    {deq, _} = Exq.RedisQueue.dequeue(:testredis, "test", "default")
     assert deq != :none
-    assert Exq.RedisQueue.dequeue(:testredis, "test", "default") == :none
+    {deq, _} = Exq.RedisQueue.dequeue(:testredis, "test", "default")
+    assert deq == :none
   end
 
   test "enqueue/dequeue multi queue" do
     Exq.RedisQueue.enqueue(:testredis, "test", "default", "MyWorker", [])
     Exq.RedisQueue.enqueue(:testredis, "test", "myqueue", "MyWorker", [])
-    assert Exq.RedisQueue.dequeue(:testredis, "test", ["default", "myqueue"]) != :none
-    assert Exq.RedisQueue.dequeue(:testredis, "test", ["default", "myqueue"]) != :none
-    assert Exq.RedisQueue.dequeue(:testredis, "test", ["default", "myqueue"]) == :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default", "myqueue"]), 0) != :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default", "myqueue"]), 0) != :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default", "myqueue"]), 0) == :none
   end
 
   test "full_key" do
@@ -36,7 +37,7 @@ defmodule Exq.RedisQueueTest do
     jid = Exq.RedisQueue.enqueue(:testredis, "test", "default", "MyWorker", [])
     assert jid != nil
 
-    job_str = Exq.RedisQueue.dequeue(:testredis, "test", "default")
+    {job_str, _} = Exq.RedisQueue.dequeue(:testredis, "test", "default")
     job = Poison.decode!(job_str, as: Exq.Job)
     assert job.jid == jid
   end

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -32,42 +32,42 @@ defmodule WorkerTest do
     end
   end
 
+  def start_worker(job) do
+    work_table = :ets.new(:work_table, [:set, :public])
+    Exq.Worker.start(
+      job,
+      nil,
+      "default",
+      work_table)
+  end
+
   test "execute valid job with perform" do
-    {:ok, worker} = Exq.Worker.start(
-      "{ \"queue\": \"default\", \"class\": \"WorkerTest.NoArgWorker\", \"args\": [] }")
+    {:ok, worker} = start_worker("{ \"queue\": \"default\", \"class\": \"WorkerTest.NoArgWorker\", \"args\": [] }")
     assert_terminate(worker, true)
   end
 
   test "execute valid job with perform args" do
-    {:ok, worker} = Exq.Worker.start(
-      "{ \"queue\": \"default\", \"class\": \"WorkerTest.ThreeArgWorker\", \"args\": [1, 2, 3] }")
+    {:ok, worker} = start_worker("{ \"queue\": \"default\", \"class\": \"WorkerTest.ThreeArgWorker\", \"args\": [1, 2, 3] }")
     assert_terminate(worker, true)
   end
 
   test "execute valid job with custom function" do
-    {:ok, worker} = Exq.Worker.start(
-      "{ \"queue\": \"default\", \"class\": \"WorkerTest.CustomMethodWorker/custom_perform\", \"args\": [] }")
+    {:ok, worker} = start_worker("{ \"queue\": \"default\", \"class\": \"WorkerTest.CustomMethodWorker/custom_perform\", \"args\": [] }")
     assert_terminate(worker, true)
   end
 
   test "execute job with invalid JSON" do
-    {:ok, worker} = Exq.Worker.start(
-      "{ invalid: json: this: is}")
+    {:ok, worker} = start_worker("{ invalid: json: this: is}")
     assert_terminate(worker, false)
   end
 
   test "execute invalid module perform" do
-    {:ok, worker} = Exq.Worker.start(
-      "{ \"queue\": \"default\", \"class\": \"NonExistant\", \"args\": [] }")
+    {:ok, worker} = start_worker("{ \"queue\": \"default\", \"class\": \"NonExistant\", \"args\": [] }")
     assert_terminate(worker, false)
   end
 
   test "execute invalid module function" do
-    {:ok, worker} = Exq.Worker.start(
-      "{ \"queue\": \"default\", \"class\": \"WorkerTest.MissingMethodWorker/nonexist\", \"args\": [] }")
+    {:ok, worker} = start_worker("{ \"queue\": \"default\", \"class\": \"WorkerTest.MissingMethodWorker/nonexist\", \"args\": [] }")
     assert_terminate(worker, false)
   end
-
-
-
 end


### PR DESCRIPTION
Keep a count on the manager level and throttle if going over this count.
This is a simple solution for now - could be changed once we go to Queue level
concurrency / worker supervision