### PR TITLE
Handle JSON parsing errors in Exq.Stats.remove_process

### DIFF
--- a/lib/exq/job.ex
+++ b/lib/exq/job.ex
@@ -1,10 +1,18 @@
 
 defmodule Exq.Json do
   def decode(json) do
-    Poison.decode!(json)
+    Poison.decode(json)
   end
 
   def encode(e) do
+    Poison.encode(e)
+  end
+
+  def decode!(json) do
+    Poison.decode!(json)
+  end
+
+  def encode!(e) do
     Poison.encode!(e)
   end
 end
@@ -46,6 +54,6 @@ defmodule Exq.Job do
       queue: job.queue,
       retry: job.retry,
       retry_count: job.retry_count], HashDict.new)
-    Exq.Json.encode(job)
+    Exq.Json.encode!(job)
   end
 end

--- a/lib/exq/job.ex
+++ b/lib/exq/job.ex
@@ -24,7 +24,7 @@ defmodule Exq.Job do
 
 
   def from_json(json_str) do
-    json = Exq.Json.decode(json_str)
+    json = Exq.Json.decode!(json_str)
     job = %Exq.Job{
       args: Dict.get(json, "args"),
       class: Dict.get(json, "class"),

--- a/lib/exq/redis_queue.ex
+++ b/lib/exq/redis_queue.ex
@@ -61,6 +61,6 @@ defmodule Exq.RedisQueue do
   defp job_json(queue, worker, args) do
     jid = UUID.uuid4
     job = Enum.into([{:queue, queue}, {:class, worker}, {:args, args}, {:jid, jid}, {:enqueued_at, DateFormat.format!(Date.local, "{ISO}")}], HashDict.new)
-    {jid, Exq.Json.encode(job)}
+    {jid, Exq.Json.encode!(job)}
   end
 end


### PR DESCRIPTION
I was running into an issue that was causing exq to crash when `Exq.Stats.remove_process` was called. The reason for the crash was due to JSON parsing errors when reading from the `processes` set in Redis.

While vanilla Sidekiq only places valid JSON into `processes`, there are a few common Ruby Sidekiq plugins which insert other things. In my case, the [sidekiq-limit_fetch](https://github.com/brainopia/sidekiq-limit_fetch) plugin was inserting string hashes into the `processes` set.

So I've wrapped Poison's non-bang `encode()` and `decode()` functions in `Exq.Json`, and renamed the previous `encode()` and `decode()` functions there to match the underlying Poison function (ie. `encode!()` and `decode!()`)

If this change breaks things for people *(perhaps they were relying on the existing `Exq.Json` API in their own projects?)*, an alternative would be to create a function `Exq.Json.safe_decode()` that calls the non-bang version of `Poison.decode()`, and then only the `Exq.Stats.remove_process` function would need to use it. Let me know if this is preferred to renaming the functions.

Finally, as per the instructions at the bottom of README.md, I attempted to run the tests after my changes and quite a few fail. However after reverting to master and running the tests again, I see the same errors. Therefore I'm pretty sure the tests were already failing and my changes have not introduced anything new.