### PR TITLE
Add scheduled jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ config :exq,
   password: "optional_redis_auth",
   namespace: "exq",
   concurrency: :infinite,
-  queues: ["default"]
+  queues: ["default"],
+  poll_timeout: 50,
+  scheduler_enable: false,
+  scheduler_poll_timeout: 200,
 ```
 
 ### Concurrency:
@@ -134,6 +137,18 @@ You can also enqueue jobs without starting workers:
 
 {:ok, ack} = Exq.Enqueuer.enqueue(:exq_enqueuer, "default", "MyWorker", [])
 
+```
+You can also schedule jobs to start at a future time:
+You need to make scheduler_enable is set to true
+
+Schedule a job to start in 5 mins
+```elixir
+{:ok, ack} = Exq.enqueue_in(:exq, "default", 300, "MyWorker", ["arg1", "arg2"])
+```
+Schedule a job to start at 8am 2015-12-25 UTC
+```elixir
+time = Timex.Date.from({{2015, 12, 25}, {8, 0, 0}}) |> Timex.Date.to_timestamp
+{:ok, ack} = Exq.enqueue_at(:exq, "default", time, "MyWorker", ["arg1", "arg2"])
 ```
 
 ### Creating Workers:

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You can also enqueue jobs without starting workers:
 
 ```
 You can also schedule jobs to start at a future time:
-You need to make scheduler_enable is set to true
+You need to make sure scheduler_enable is set to true
 
 Schedule a job to start in 5 mins
 ```elixir

--- a/lib/exq.ex
+++ b/lib/exq.ex
@@ -1,6 +1,5 @@
 defmodule Exq do
   require Logger
-  import Supervisor.Spec
   use Application
 
   # OTP Application

--- a/lib/exq.ex
+++ b/lib/exq.ex
@@ -29,4 +29,11 @@ defmodule Exq do
     GenServer.call(pid, {:enqueue, queue, worker, args})
   end
 
+  def enqueue_at(pid, queue, time, worker, args) do
+    GenServer.call(pid, {:enqueue_at, queue, time, worker, args})
+  end
+
+  def enqueue_in(pid, queue, offset, worker, args) do
+    GenServer.call(pid, {:enqueue_in, queue, offset, worker, args})
+  end
 end

--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -36,7 +36,9 @@ defmodule Exq.Api do
   def queue_size(pid) do
     GenServer.call(pid, {:queue_size})
   end
-
+  def queue_size(pid, :scheduled) do
+    GenServer.call(pid, {:queue_size, :scheduled})
+  end
   def queue_size(pid, queue) do
     GenServer.call(pid, {:queue_size, queue})
   end

--- a/lib/exq/enqueuer.ex
+++ b/lib/exq/enqueuer.ex
@@ -26,6 +26,23 @@ defmodule Exq.Enqueuer do
     GenServer.cast(pid, {:enqueue, from, queue, worker, args})
   end
 
+  def enqueue_at(pid, queue, time, worker, args) do
+    GenServer.call(pid, {:enqueue_at, queue, time, worker, args})
+  end
+
+  # Sync call, replies to "from" sender
+  def enqueue_at(pid, from, queue, time, worker, args) do
+    GenServer.cast(pid, {:enqueue_at, from, queue, time, worker, args})
+  end
+
+  def enqueue_in(pid, queue, offset, worker, args) do
+    GenServer.call(pid, {:enqueue_in, queue, offset, worker, args})
+  end
+
+  # Sync call, replies to "from" sender
+  def enqueue_in(pid, from, queue, offset, worker, args) do
+    GenServer.cast(pid, {:enqueue_in, from, queue, offset, worker, args})
+  end
 
   def queues(pid) do
     GenServer.call(pid, {:queues})
@@ -101,8 +118,30 @@ defmodule Exq.Enqueuer do
     {:noreply, state}
   end
 
+  def handle_cast({:enqueue_at, from, queue, time, worker, args}, state) do
+    jid = Exq.RedisQueue.enqueue_at(state.redis, state.namespace, queue, time, worker, args)
+    GenServer.reply(from, {:ok, jid})
+    {:noreply, state}
+  end
+
+  def handle_cast({:enqueue_in, from, queue, offset, worker, args}, state) do
+    jid = Exq.RedisQueue.enqueue_in(state.redis, state.namespace, queue, offset, worker, args)
+    GenServer.reply(from, {:ok, jid})
+    {:noreply, state}
+  end
+
   def handle_call({:enqueue, queue, worker, args}, _from, state) do
     jid = Exq.RedisQueue.enqueue(state.redis, state.namespace, queue, worker, args)
+    {:reply, {:ok, jid}, state}
+  end
+
+  def handle_call({:enqueue_at, queue, time, worker, args}, _from, state) do
+    jid = Exq.RedisQueue.enqueue_at(state.redis, state.namespace, queue, time, worker, args)
+    {:reply, {:ok, jid}, state}
+  end
+
+  def handle_call({:enqueue_in, queue, offset, worker, args}, _from, state) do
+    jid = Exq.RedisQueue.enqueue_in(state.redis, state.namespace, queue, offset, worker, args)
     {:reply, {:ok, jid}, state}
   end
 

--- a/lib/exq/manager.ex
+++ b/lib/exq/manager.ex
@@ -1,7 +1,6 @@
 defmodule Exq.Manager do
   require Logger
   use GenServer
-  use Timex
 
   @default_name :exq
 

--- a/lib/exq/redis.ex
+++ b/lib/exq/redis.ex
@@ -81,6 +81,11 @@ defmodule Exq.Redis do
     items
   end
 
+  def lrem!(redis, list, value, count \\ 1) do
+    {:ok, res} = :eredis.q(redis, ["LREM", list, count, value])
+    res
+  end
+
   def rpush!(redis, key, value) do
     {:ok, res} = :eredis.q(redis, ["RPUSH", key, value])
     res
@@ -103,7 +108,7 @@ defmodule Exq.Redis do
     count
   end
 
-  def zrangebyscore!(redis, set, min, max) do
+  def zrangebyscore!(redis, set, min \\ "0", max \\ "+inf") do
     {:ok, items} = :eredis.q(redis, ["ZRANGEBYSCORE", set, min, max])
     items
   end

--- a/lib/exq/redis.ex
+++ b/lib/exq/redis.ex
@@ -92,4 +92,25 @@ defmodule Exq.Redis do
       {:ok, value} -> value
     end
   end
+
+  def zadd!(redis, set, score, member) do
+    {:ok, res} = :eredis.q(redis, ["ZADD", set, score, member])
+    res
+  end
+
+  def zcard!(redis, set) do
+    {:ok, count} = :eredis.q(redis, ["ZCARD", set])
+    count
+  end
+
+  def zrangebyscore!(redis, set, min, max) do
+    {:ok, items} = :eredis.q(redis, ["ZRANGEBYSCORE", set, min, max])
+    items
+  end
+
+  def zrem!(redis, set, member) do
+    {:ok, res} = :eredis.q(redis, ["ZREM", set, member])
+    res
+  end
+
 end

--- a/lib/exq/redis_queue.ex
+++ b/lib/exq/redis_queue.ex
@@ -47,16 +47,12 @@ defmodule Exq.RedisQueue do
       ["RPUSH", queue_key(namespace, queue), job_json]])
   end
 
-  def enqueue_at(redis, namespace, queue, time, worker, args) do
-    enqueued_at = DateFormat.format!(Date.from(time, :timestamp) |> Date.local, "{ISO}")
-    {jid, job_json} = to_job_json(queue, worker, args, enqueued_at)
-    score = time_to_score(time)
-    Exq.Redis.zadd!(redis, scheduled_queue_key(namespace), score, job_json)
-    jid
-  end
-
   def enqueue_in(redis, namespace, queue, offset, worker, args) do
     time = Time.add(Time.now, Time.from(offset, :secs))
+    enqueue_at(redis, namespace, queue, time, worker, args)
+  end
+
+  def enqueue_at(redis, namespace, queue, time, worker, args) do
     enqueued_at = DateFormat.format!(Date.from(time, :timestamp) |> Date.local, "{ISO}")
     {jid, job_json} = to_job_json(queue, worker, args, enqueued_at)
     score = time_to_score(time)

--- a/lib/exq/redis_queue.ex
+++ b/lib/exq/redis_queue.ex
@@ -48,7 +48,7 @@ defmodule Exq.RedisQueue do
   end
 
   def enqueue_in(redis, namespace, queue, offset, worker, args) do
-    time = Time.add(Time.now, Time.from(offset, :secs))
+    time = Time.add(Time.now, Time.from(offset * 1_000_000, :usecs))
     enqueue_at(redis, namespace, queue, time, worker, args)
   end
 
@@ -118,10 +118,10 @@ defmodule Exq.RedisQueue do
     end
   end
 
-  defp to_job_json(queue, worker, args) do
+  def to_job_json(queue, worker, args) do
     to_job_json(queue, worker, args, DateFormat.format!(Date.local, "{ISO}"))
   end
-  defp to_job_json(queue, worker, args, enqueued_at) do
+  def to_job_json(queue, worker, args, enqueued_at) do
     jid = UUID.uuid4
     job = Enum.into([{:queue, queue}, {:class, worker}, {:args, args}, {:jid, jid}, {:enqueued_at, enqueued_at}], HashDict.new)
     {jid, Exq.Json.encode!(job)}

--- a/lib/exq/redis_queue.ex
+++ b/lib/exq/redis_queue.ex
@@ -23,10 +23,27 @@ defmodule Exq.RedisQueue do
   end
 
   def enqueue(redis, namespace, queue, worker, args) do
-    {jid, job} = job_json(queue, worker, args)
+    {jid, job_json} = to_job_json(queue, worker, args)
+    enqueue(redis, namespace, queue, job_json)
+    jid
+  end
+  def enqueue(redis, namespace, queue, job_json) do
     [{:ok, _}, {:ok, _}] = :eredis.qp(redis, [
       ["SADD", full_key(namespace, "queues"), queue],
-      ["RPUSH", queue_key(namespace, queue), job]])
+      ["RPUSH", queue_key(namespace, queue), job_json]])
+  end
+
+  def enqueue_at(redis, namespace, queue, time, worker, args) do
+    {jid, job_json} = to_job_json(queue, worker, args)
+    score = round(time)
+    Exq.Redis.zadd!(redis, scheduled_queue_key(namespace, queue), score, job_json)
+    jid
+  end
+
+  def enqueue_in(redis, namespace, queue, offset, worker, args) do
+    {jid, job_json} = to_job_json(queue, worker, args)
+    score = round(Time.now(:secs) + offset)
+    Exq.Redis.zadd!(redis, scheduled_queue_key(namespace, queue), score, job_json)
     jid
   end
 
@@ -36,6 +53,25 @@ defmodule Exq.RedisQueue do
   def dequeue(redis, namespace, queue) do
     {Exq.Redis.lpop!(redis, queue_key(namespace, queue)), queue}
   end
+
+  def scheduler_dequeue(redis, namespace, queues) do
+    max_score = round(Time.now(:secs))
+    Exq.Shuffle.shuffle(queues)
+      |> Enum.each(fn(queue) ->
+        Exq.Redis.zrangebyscore!(redis, scheduled_queue_key(namespace, queue), 0, max_score)
+          |> scheduler_dequeue_requeue(redis, namespace, queue, 0)
+      end)
+  end
+
+  def scheduler_dequeue_requeue([], _redis, _namespace, _queue, count), do: count
+  def scheduler_dequeue_requeue([h|t], redis, namespace, queue, count) do
+    if Exq.Redis.zrem!(redis, scheduled_queue_key(namespace, queue), h) == "1" do
+      enqueue(redis, namespace, queue, h)
+      count = count + 1
+    end
+    scheduler_dequeue_requeue(t, redis, namespace, queue, count)
+  end
+
 
   def full_key("", key), do: key
   def full_key(nil, key), do: key
@@ -47,7 +83,11 @@ defmodule Exq.RedisQueue do
     full_key(namespace, "queue:#{queue}")
   end
 
-  defp dequeue_random(redis, namespace, []) do
+  def scheduled_queue_key(namespace, queue) do
+    full_key(namespace, "scheduled:#{queue}")
+  end
+
+  defp dequeue_random(_redis, _namespace, []) do
     {nil, nil}
   end
   defp dequeue_random(redis, namespace, queues) do
@@ -58,7 +98,7 @@ defmodule Exq.RedisQueue do
     end
   end
 
-  defp job_json(queue, worker, args) do
+  defp to_job_json(queue, worker, args) do
     jid = UUID.uuid4
     job = Enum.into([{:queue, queue}, {:class, worker}, {:args, args}, {:jid, jid}, {:enqueued_at, DateFormat.format!(Date.local, "{ISO}")}], HashDict.new)
     {jid, Exq.Json.encode!(job)}

--- a/lib/exq/scheduler.ex
+++ b/lib/exq/scheduler.ex
@@ -50,7 +50,7 @@ defmodule Exq.Scheduler do
   end
 
   def handle_call({:stop}, _from, state) do
-    { :stop, :normal, :ok, state }
+    {:stop, :normal, :ok, state}
   end
 
   def handle_call(_request, _from, state) do
@@ -61,16 +61,6 @@ defmodule Exq.Scheduler do
   def handle_info(:timeout, state) do
     {updated_state, timeout} = dequeue(state)
     {:noreply, updated_state, timeout}
-  end
-
-  def code_change(_old_version, state, _extra) do
-    {:ok, state}
-  end
-
-  def terminate(_reason, state) do
-    GenServer.call(state.stats, {:stop})
-    :eredis.stop(state.redis)
-    :ok
   end
 
 ##===========================================================

--- a/lib/exq/scheduler.ex
+++ b/lib/exq/scheduler.ex
@@ -6,7 +6,7 @@ defmodule Exq.Scheduler do
   @default_name :exq_scheduler
 
   defmodule State do
-    defstruct redis: nil, namespace: nil, queues: nil, sched_poll_timeout: nil
+    defstruct redis: nil, namespace: nil, queues: nil, scheduler_poll_timeout: nil
   end
 
   def start(opts \\ []) do
@@ -29,14 +29,14 @@ defmodule Exq.Scheduler do
   def init([opts]) do
     namespace = Keyword.get(opts, :namespace, Exq.Config.get(:namespace, "exq"))
     queues = Keyword.get(opts, :queues)
-    sched_poll_timeout = Keyword.get(opts, :sched_poll_timeout, Exq.Config.get(:sched_poll_timeout, "exq"))
+    scheduler_poll_timeout = Keyword.get(opts, :scheduler_poll_timeout, Exq.Config.get(:scheduler_poll_timeout, "exq"))
     redis = case Keyword.get(opts, :redis) do
       nil ->
         {:ok, r} = Exq.Redis.connection(opts)
         r
       r -> r
     end
-    state = %State{redis: redis, namespace: namespace, queues: queues, sched_poll_timeout: sched_poll_timeout}
+    state = %State{redis: redis, namespace: namespace, queues: queues, scheduler_poll_timeout: scheduler_poll_timeout}
     {:ok, state}
   end
 
@@ -79,7 +79,7 @@ defmodule Exq.Scheduler do
 
   def dequeue(state) do
     Exq.RedisQueue.scheduler_dequeue(state.redis, state.namespace, state.queues)
-    {state, state.sched_poll_timeout}
+    {state, state.scheduler_poll_timeout}
   end
 
   def default_name, do: @default_name

--- a/lib/exq/scheduler.ex
+++ b/lib/exq/scheduler.ex
@@ -1,0 +1,90 @@
+defmodule Exq.Scheduler do
+  require Logger
+  use GenServer
+  use Timex
+
+  @default_name :exq_scheduler
+
+  defmodule State do
+    defstruct redis: nil, namespace: nil, queues: nil, sched_poll_timeout: nil
+  end
+
+  def start(opts \\ []) do
+    GenServer.start(__MODULE__, [opts])
+  end
+
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, @default_name)
+    GenServer.start_link(__MODULE__, [opts], [{:name, name}])
+  end
+
+  def start_timeout(pid) do
+    GenServer.cast(pid, {:start_timeout})
+  end
+
+##===========================================================
+## gen server callbacks
+##===========================================================
+
+  def init([opts]) do
+    namespace = Keyword.get(opts, :namespace, Exq.Config.get(:namespace, "exq"))
+    queues = Keyword.get(opts, :queues)
+    sched_poll_timeout = Keyword.get(opts, :sched_poll_timeout, Exq.Config.get(:sched_poll_timeout, "exq"))
+    redis = case Keyword.get(opts, :redis) do
+      nil ->
+        {:ok, r} = Exq.Redis.connection(opts)
+        r
+      r -> r
+    end
+    state = %State{redis: redis, namespace: namespace, queues: queues, sched_poll_timeout: sched_poll_timeout}
+    {:ok, state}
+  end
+
+  def handle_cast({:start_timeout}, state) do
+    handle_info(:timeout, state)
+  end
+
+  def handle_cast(_request, state) do
+    Logger.error("UKNOWN CAST")
+    {:noreply, state, 0}
+  end
+
+  def handle_call({:stop}, _from, state) do
+    { :stop, :normal, :ok, state }
+  end
+
+  def handle_call(_request, _from, state) do
+    Logger.error("UKNOWN CALL")
+    {:reply, :unknown, state, 0}
+  end
+
+  def handle_info(:timeout, state) do
+    {updated_state, timeout} = dequeue(state)
+    {:noreply, updated_state, timeout}
+  end
+
+  def code_change(_old_version, state, _extra) do
+    {:ok, state}
+  end
+
+  def terminate(_reason, state) do
+    GenServer.call(state.stats, {:stop})
+    :eredis.stop(state.redis)
+    :ok
+  end
+
+##===========================================================
+## Internal Functions
+##===========================================================
+
+  def dequeue(state) do
+    Exq.RedisQueue.scheduler_dequeue(state.redis, state.namespace, state.queues)
+    {state, state.sched_poll_timeout}
+  end
+
+  def default_name, do: @default_name
+
+  def stop(_pid) do
+  end
+
+end

--- a/lib/exq/scheduler.ex
+++ b/lib/exq/scheduler.ex
@@ -1,7 +1,6 @@
 defmodule Exq.Scheduler do
   require Logger
   use GenServer
-  use Timex
 
   @default_name :exq_scheduler
 

--- a/lib/exq/scheduler_sup.ex
+++ b/lib/exq/scheduler_sup.ex
@@ -1,0 +1,20 @@
+defmodule Exq.Scheduler.Supervisor do
+  use Supervisor
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, [opts], name: supervisor_name(opts))
+  end
+
+  def init([opts]) do
+    children = [worker(Exq.Scheduler, [opts])]
+    supervise(children, strategy: :one_for_one, max_restarts: 20)
+  end
+
+  defp server_name(opts) do
+    Keyword.get(opts, :name, Exq.Scheduler.default_name)
+  end
+
+  defp supervisor_name(opts) do
+    String.to_atom("#{server_name(opts)}_sup")
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule Exq.Mixfile do
       { :uuid, "~> 1.0.0" },
       { :eredis, "~> 1.0.8"},
       { :poison, ">= 1.2.0 and < 2.0.0"},
-      { :timex, "~> 0.13.0" },
+      { :timex, "~> 0.13.5" },
       { :plug, ">= 0.8.1 and < 1.0.0"},
       { :cowboy, "~> 1.0" },
       { :excoveralls, "~> 0.3", only: :test }

--- a/mix.lock
+++ b/mix.lock
@@ -11,5 +11,4 @@
   "ranch": {:hex, :ranch, "1.0.0"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
   "timex": {:hex, :timex, "0.13.5"},
-  "tzdata": {:hex, :tzdata, "0.1.6"},
   "uuid": {:hex, :uuid, "1.0.0"}}

--- a/mix.lock
+++ b/mix.lock
@@ -10,5 +10,6 @@
   "poison": {:hex, :poison, "1.4.0"},
   "ranch": {:hex, :ranch, "1.0.0"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
-  "timex": {:hex, :timex, "0.13.0"},
+  "timex": {:hex, :timex, "0.13.5"},
+  "tzdata": {:hex, :tzdata, "0.1.6"},
   "uuid": {:hex, :uuid, "1.0.0"}}

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -74,6 +74,26 @@ defmodule ExqTest do
     stop_process(sup)
   end
 
+  test "enqueue_in and run a job" do
+    Process.register(self, :exqtest)
+    {:ok, sup} = Exq.start_link([name: :exq_t, port: 6555, namespace: "test",
+                                 scheduler_enable: true, scheduler_poll_timeout: 5])
+    {:ok, _} = Exq.enqueue_in(:exq_t, "default", 0, "ExqTest.PerformWorker", [])
+    wait_long
+    assert_received {:worked}
+    stop_process(sup)
+  end
+
+  test "enqueue_at and run a job" do
+    Process.register(self, :exqtest)
+    {:ok, sup} = Exq.start_link([name: :exq_t, port: 6555, namespace: "test",
+                                 scheduler_enable: true, scheduler_poll_timeout: 5])
+    {:ok, _} = Exq.enqueue_at(:exq_t, "default", Timex.Time.now, "ExqTest.PerformWorker", [])
+    wait_long
+    assert_received {:worked}
+    stop_process(sup)
+  end
+
   test "enqueue with separate enqueuer" do
     Process.register(self, :exqtest)
     {:ok, exq_sup} = Exq.start_link([name: :exq_t, port: 6555, namespace: "test"])

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -3,6 +3,7 @@ Code.require_file "test_helper.exs", __DIR__
 
 defmodule ExqTest do
   use ExUnit.Case
+  use Timex
   import ExqTestUtil
 
   defmodule PerformWorker do
@@ -88,7 +89,7 @@ defmodule ExqTest do
     Process.register(self, :exqtest)
     {:ok, sup} = Exq.start_link([name: :exq_t, port: 6555, namespace: "test",
                                  scheduler_enable: true, scheduler_poll_timeout: 5])
-    {:ok, _} = Exq.enqueue_at(:exq_t, "default", Timex.Time.now, "ExqTest.PerformWorker", [])
+    {:ok, _} = Exq.enqueue_at(:exq_t, "default", Time.now, "ExqTest.PerformWorker", [])
     wait_long
     assert_received {:worked}
     stop_process(sup)

--- a/test/performance_test.exs
+++ b/test/performance_test.exs
@@ -22,6 +22,15 @@ defmodule PerformanceTest do
     end
   end
 
+  test "test to_job_json performance" do
+    started = :os.timestamp
+    max_timeout_ms = 3_000
+    for _ <- 1..5000, do: Exq.RedisQueue.to_job_json("default", "PerformanceTest.Worker", ["keep_on_trucking"])
+    elapsed_ms = :timer.now_diff(:os.timestamp, started) / 1_000
+    Logger.debug "to_job_json performance test took #{elapsed_ms / 1_000} secs"
+    assert elapsed_ms < max_timeout_ms
+  end
+
   test "performance is in acceptable range" do
 
     Process.register(self(), :tester)
@@ -41,7 +50,7 @@ defmodule PerformanceTest do
     end
 
     elapsed_ms = :timer.now_diff(:os.timestamp, started) / 1_000
-    Logger.debug "Perf test took #{elapsed_ms / 1_000} ms"
+    Logger.debug "Perf test took #{elapsed_ms / 1_000} secs"
     count = Exq.Redis.llen!(:testredis, "test:queue:default")
 
     assert count == "0"

--- a/test/redis_queue_test.exs
+++ b/test/redis_queue_test.exs
@@ -2,6 +2,7 @@ Code.require_file "test_helper.exs", __DIR__
 
 defmodule Exq.RedisQueueTest do
   use ExUnit.Case
+  use Timex
 
   setup_all do
     TestRedis.setup
@@ -31,9 +32,9 @@ defmodule Exq.RedisQueueTest do
     Exq.RedisQueue.enqueue_in(:testredis, "test", "default", 0, "MyWorker", [])
     Exq.RedisQueue.enqueue_in(:testredis, "test", "default", 0, "MyWorker", [])
     assert Exq.RedisQueue.scheduler_dequeue(:testredis, "test", ["default"]) == 2
-    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default"]), 0) != :none
-    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default"]), 0) != :none
-    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default"]), 0) == :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", "default"), 0) != :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", "default"), 0) != :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", "default"), 0) == :none
   end
 
   test "scheduler_dequeue multi queue" do
@@ -45,11 +46,43 @@ defmodule Exq.RedisQueueTest do
     assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default", "myqueue"]), 0) == :none
   end
 
-  test "enqueue_at" do
+  test "scheduler_dequeue enqueue_at" do
     Exq.RedisQueue.enqueue_at(:testredis, "test", "default", Timex.Time.now, "MyWorker", [])
     assert Exq.RedisQueue.scheduler_dequeue(:testredis, "test", ["default"]) == 1
-    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default"]), 0) != :none
-    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default"]), 0) == :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", "default"), 0) != :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", "default"), 0) == :none
+  end
+
+  test "scheduler_dequeue max_score" do
+    now = Time.now
+    time1 = Time.add(now, Time.from(340, :secs))
+    Exq.RedisQueue.enqueue_at(:testredis, "test", "default", time1, "MyWorker", [])
+    time2 = Time.add(now, Time.from(350, :secs))
+    time2a = Time.add(now, Time.from(351, :secs))
+    Exq.RedisQueue.enqueue_at(:testredis, "test", "default", time2, "MyWorker", [])
+    time3 = Time.add(now, Time.from(360, :secs))
+    time3a = Time.add(now, Time.from(359, :secs))
+    Exq.RedisQueue.enqueue_at(:testredis, "test", "default", time3, "MyWorker", [])
+    time4 = Time.add(now, Time.from(360000001, :usecs))
+    Exq.RedisQueue.enqueue_at(:testredis, "test", "default", time4, "MyWorker", [])
+
+    assert Exq.Enqueuer.queue_size(:testredis, "test", "default") == "0"
+    assert Exq.Enqueuer.queue_size(:testredis, "test", :scheduled) == "4"
+
+    assert Exq.RedisQueue.scheduler_dequeue(:testredis, "test", ["default"], Exq.RedisQueue.time_to_score(time2a)) == 2
+    assert Exq.RedisQueue.scheduler_dequeue(:testredis, "test", ["default"], Exq.RedisQueue.time_to_score(time3a)) == 0
+    assert Exq.RedisQueue.scheduler_dequeue(:testredis, "test", ["default"], Exq.RedisQueue.time_to_score(time3)) == 1
+    assert Exq.RedisQueue.scheduler_dequeue(:testredis, "test", ["default"], Exq.RedisQueue.time_to_score(time3)) == 0
+    assert Exq.RedisQueue.scheduler_dequeue(:testredis, "test", ["default"], Exq.RedisQueue.time_to_score(time4)) == 1
+
+    assert Exq.Enqueuer.queue_size(:testredis, "test", "default") == "4"
+    assert Exq.Enqueuer.queue_size(:testredis, "test", :scheduled) == "0"
+
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", "default"), 0) != :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", "default"), 0) != :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", "default"), 0) != :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", "default"), 0) != :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", "default"), 0) == :none
   end
 
   test "full_key" do

--- a/test/redis_queue_test.exs
+++ b/test/redis_queue_test.exs
@@ -27,6 +27,31 @@ defmodule Exq.RedisQueueTest do
     assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default", "myqueue"]), 0) == :none
   end
 
+  test "scheduler_dequeue single queue" do
+    Exq.RedisQueue.enqueue_in(:testredis, "test", "default", 0, "MyWorker", [])
+    Exq.RedisQueue.enqueue_in(:testredis, "test", "default", 0, "MyWorker", [])
+    assert Exq.RedisQueue.scheduler_dequeue(:testredis, "test", ["default"]) == 2
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default"]), 0) != :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default"]), 0) != :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default"]), 0) == :none
+  end
+
+  test "scheduler_dequeue multi queue" do
+    Exq.RedisQueue.enqueue_in(:testredis, "test", "default", -1, "MyWorker", [])
+    Exq.RedisQueue.enqueue_in(:testredis, "test", "myqueue", -1, "MyWorker", [])
+    assert Exq.RedisQueue.scheduler_dequeue(:testredis, "test", ["default", "myqueue"]) == 2
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default", "myqueue"]), 0) != :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default", "myqueue"]), 0) != :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default", "myqueue"]), 0) == :none
+  end
+
+  test "enqueue_at" do
+    Exq.RedisQueue.enqueue_at(:testredis, "test", "default", Timex.Time.now, "MyWorker", [])
+    assert Exq.RedisQueue.scheduler_dequeue(:testredis, "test", ["default"]) == 1
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default"]), 0) != :none
+    assert elem(Exq.RedisQueue.dequeue(:testredis, "test", ["default"]), 0) == :none
+  end
+
   test "full_key" do
     assert Exq.RedisQueue.full_key("exq","k1") == "exq:k1"
     assert Exq.RedisQueue.full_key("","k1") == "k1"
@@ -43,4 +68,3 @@ defmodule Exq.RedisQueueTest do
   end
 
 end
-

--- a/test/redis_test.exs
+++ b/test/redis_test.exs
@@ -38,6 +38,36 @@ defmodule Exq.RedisTest do
     assert Exq.Redis.lpop!(:testredis, "akey")  == :none
   end
 
+  test "zadd / zcard / zrem" do
+    assert Exq.Redis.zcard!(:testredis, "akey") == "0"
+    assert Exq.Redis.zadd!(:testredis, "akey", "1.7", "avalue") == "1"
+    assert Exq.Redis.zcard!(:testredis, "akey") == "1"
+    assert Exq.Redis.zrem!(:testredis, "akey", "avalue") == "1"
+    assert Exq.Redis.zcard!(:testredis, "akey") == "0"
+  end
+
+  test "zrangebyscore" do
+    assert Exq.Redis.zcard!(:testredis, "akey") == "0"
+    assert Exq.Redis.zadd!(:testredis, "akey", "123456.123455", "avalue") == "1"
+    assert Exq.Redis.zadd!(:testredis, "akey", "123456.123456", "bvalue") == "1"
+    assert Exq.Redis.zadd!(:testredis, "akey", "123456.123457", "cvalue") == "1"
+
+    assert Exq.Redis.zrangebyscore!(:testredis, "akey", 0, "111111.111111") == []
+    assert Exq.Redis.zrangebyscore!(:testredis, "akey", 0, "123456.123455") == ["avalue"]
+    assert Exq.Redis.zrangebyscore!(:testredis, "akey", 0, "123456.123456") == ["avalue", "bvalue"]
+    assert Exq.Redis.zrangebyscore!(:testredis, "akey", 0, "123456.123457") == ["avalue", "bvalue", "cvalue"]
+    assert Exq.Redis.zrangebyscore!(:testredis, "akey", 0, "999999.999999") == ["avalue", "bvalue", "cvalue"]
+
+    assert Exq.Redis.zrem!(:testredis, "akey", "bvalue") == "1"
+    assert Exq.Redis.zrangebyscore!(:testredis, "akey", 0, "123456.123457") == ["avalue", "cvalue"]
+    assert Exq.Redis.zrem!(:testredis, "akey", "avalue") == "1"
+    assert Exq.Redis.zrangebyscore!(:testredis, "akey", 0, "123456.123456") == []
+    assert Exq.Redis.zrangebyscore!(:testredis, "akey", 0, "123456.123457") == ["cvalue"]
+    assert Exq.Redis.zrem!(:testredis, "akey", "avalue") == "0"
+    assert Exq.Redis.zrem!(:testredis, "akey", "cvalue") == "1"
+    assert Exq.Redis.zrangebyscore!(:testredis, "akey", 0, "999999.999999") == []
+  end
+
   test "flushdb" do
     Exq.Redis.sadd!(:testredis, "theset", "amember")
     Exq.Redis.flushdb! :testredis


### PR DESCRIPTION
Based off #8 I have added a Task Scheduler, 

It uses "scheduled" queues for each "live" queue which are sorted sets, when a scheduled job's time is reached the job is pulled from the "scheduled" queue and put on the "live" queue and then the manager deals with it as normal.

I'm new to Elixir so I thought it best to get some feedback before I went any further.

It is working and api wise I think enqueue_in works but I'm not sure about the format for the time in enqueue_at, currently its a unix timestamp.

At the moment the jobs are scheduled with a 1 second resolution which works for me but I'm not sure how accurate others need the scheduling to be.

I thought my next steps should be to add a setting to enable the scheduler which would default to false and also add tests and documentation for the new functionality.