### PR TITLE
Add support for string host and password. Add test for redis config. …

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,7 +4,7 @@ config :logger, :console,
   format: "\n$date $time [$level]: $message \n"
 
 config :exq,
-  host: '127.0.0.1',
+  host: "127.0.0.1",
   port: 6379,
   namespace: "exq",
   queues: ["default"],

--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -3,12 +3,19 @@ defmodule Exq.Redis.Connection do
   alias Exq.Support.Config
 
   def connection(opts \\ []) do
+    {host, port, database, password, reconnect_on_sleep} = info(opts)
+    :eredis.start_link(host, port, database, password, reconnect_on_sleep)
+  end
+
+  def info(opts \\ []) do
     host = Keyword.get(opts, :host, Config.get(:host, '127.0.0.1'))
     port = Keyword.get(opts, :port, Config.get(:port, 6379))
     database = Keyword.get(opts, :database, Config.get(:database, 0))
-    password = Keyword.get(opts, :password, Config.get(:password, ''))
+    password = Keyword.get(opts, :password, Config.get(:password) || '')
     reconnect_on_sleep = Keyword.get(opts, :reconnect_on_sleep, Config.get(:reconnect_on_sleep, 100))
-    :eredis.start_link(host, port, database, password, reconnect_on_sleep)
+    if is_binary(host), do: host = String.to_char_list(host)
+    if is_binary(password), do: password = String.to_char_list(password)
+    {host, port, database, password, reconnect_on_sleep}
   end
 
   def flushdb!(redis) do

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -3,10 +3,14 @@ defmodule Exq.ConfigTest do
   use ExUnit.Case
   require Mix.Config
 
+  setup_all do
+    ExqTestUtil.reset_config
+  end
+
   test "Mix.Config should change the host." do
-    assert Exq.Support.Config.get(:host) == '127.0.0.1'
-    Mix.Config.persist([exq: [host: '127.1.1.1']])
-    assert Exq.Support.Config.get(:host) == '127.1.1.1'
+    assert Exq.Support.Config.get(:host) == "127.0.0.1"
+    Mix.Config.persist([exq: [host: "127.1.1.1"]])
+    assert Exq.Support.Config.get(:host) == "127.1.1.1"
   end
 
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -50,6 +50,11 @@ defmodule ExqTestUtil do
     :timer.sleep(@long_timeout)
   end
 
+  def reset_config do
+    config = Mix.Config.read!(Path.join([Path.dirname(__DIR__), "config", "config.exs"]))
+    Mix.Config.persist(config)
+  end
+
 end
 
 defmodule TestRedis do


### PR DESCRIPTION
Hi,

I made some changes in redis connection configuration.

* Transform `"hostname"` to `'hostname'` before passing it to eredis when needed.
* Transform `"password"` to `'password'` before passing it to eredis when needed. I think that `password: "optional_redis_auth"`, as written in the README, will fail otherwise.
* Use `|| ''` instead of default argument for the password. With `Config.get(:password, '')`, if `password` is explicitly set to `nil`, for example with someting like `password: System.get_env("REDIS_PASSWORD")`, the default value is not used and the password passed to eredis becomes nil, resulting in a connection error.

I also added some tests for the changes.