### PR TITLE
Add support for nested Ruby modules.

### DIFF
--- a/lib/exq/worker/server.ex
+++ b/lib/exq/worker/server.ex
@@ -25,7 +25,7 @@ defmodule Exq.Worker.Server do
   def handle_cast(:work, state) do
     job = Exq.Support.Job.from_json(state.job)
 
-    target = job.class
+    target = String.replace(job.class, "::", ".")
     [mod | func_or_empty] = Regex.split(~r/\//, target)
     func = case func_or_empty do
       [] -> :perform

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -46,6 +46,11 @@ defmodule WorkerTest do
     assert_terminate(worker, true)
   end
 
+  test "execute valid rubyish job with perform" do
+    {:ok, worker} = start_worker("{ \"queue\": \"default\", \"class\": \"WorkerTest::NoArgWorker\", \"args\": [] }")
+    assert_terminate(worker, true)
+  end
+
   test "execute valid job with perform args" do
     {:ok, worker} = start_worker("{ \"queue\": \"default\", \"class\": \"WorkerTest.ThreeArgWorker\", \"args\": [1, 2, 3] }")
     assert_terminate(worker, true)


### PR DESCRIPTION
Hi,

I am currently running a web app written in Ruby using Sidekiq
and am trying to migrate my workers to Elixir using exq, while keeping my Ruby app and using
only Sidekiq client to push the jobs.
My workers in Ruby are in nested modules (e.g. `MyApp::MyWorker`), which makes the jobs impossible to process
with exq without (AFAIK) either changing my Ruby app layout, or stopping to use Sidekiq to queue the jobs,
as the produced JSON is something like this:

```
{
  "retry":true,
  "queue":"default",
  "class":"MyApp::MyWorker",
  "args":["myarg"],
  "jid":"ded64b6bd566ee8c204eb685",
  "enqueued_at":1442650846.397662
}
```

As exq is compatible with Sidekiq and Resque, I think that allowing nested modules could
make the migration easier for cases like mine, using an existing Ruby code base.
This would allow to create an Elixir module `MyApp.MyWorker` which
would process `MyApp::MyWorker` jobs.
I do not think there should be any drawback as a name such as `MyApp::MyWorker` is not
a valid name for a module in Elixir anyway.

Cheers.