### PR TITLE
Better handling if Redis is down - bubble up errors

### DIFF
--- a/lib/exq/enqueuer/server.ex
+++ b/lib/exq/enqueuer/server.ex
@@ -40,36 +40,36 @@ defmodule Exq.Enqueuer.Server do
   end
 
   def handle_cast({:enqueue, from, queue, worker, args}, state) do
-    jid = JobQueue.enqueue(state.redis, state.namespace, queue, worker, args)
-    GenServer.reply(from, {:ok, jid})
+    response = JobQueue.enqueue(state.redis, state.namespace, queue, worker, args)
+    GenServer.reply(from, response)
     {:noreply, state}
   end
 
   def handle_cast({:enqueue_at, from, queue, time, worker, args}, state) do
-    jid = JobQueue.enqueue_at(state.redis, state.namespace, queue, time, worker, args)
-    GenServer.reply(from, {:ok, jid})
+    response = JobQueue.enqueue_at(state.redis, state.namespace, queue, time, worker, args)
+    GenServer.reply(from, response)
     {:noreply, state}
   end
 
   def handle_cast({:enqueue_in, from, queue, offset, worker, args}, state) do
-    jid = JobQueue.enqueue_in(state.redis, state.namespace, queue, offset, worker, args)
-    GenServer.reply(from, {:ok, jid})
+    response = JobQueue.enqueue_in(state.redis, state.namespace, queue, offset, worker, args)
+    GenServer.reply(from, response)
     {:noreply, state}
   end
 
   def handle_call({:enqueue, queue, worker, args}, _from, state) do
-    jid = JobQueue.enqueue(state.redis, state.namespace, queue, worker, args)
-    {:reply, {:ok, jid}, state}
+    response = JobQueue.enqueue(state.redis, state.namespace, queue, worker, args)
+    {:reply, response, state}
   end
 
   def handle_call({:enqueue_at, queue, time, worker, args}, _from, state) do
-    jid = JobQueue.enqueue_at(state.redis, state.namespace, queue, time, worker, args)
-    {:reply, {:ok, jid}, state}
+    response = JobQueue.enqueue_at(state.redis, state.namespace, queue, time, worker, args)
+    {:reply, response, state}
   end
 
   def handle_call({:enqueue_in, queue, offset, worker, args}, _from, state) do
-    jid = JobQueue.enqueue_in(state.redis, state.namespace, queue, offset, worker, args)
-    {:reply, {:ok, jid}, state}
+    response = JobQueue.enqueue_in(state.redis, state.namespace, queue, offset, worker, args)
+    {:reply, response, state}
   end
 
   def handle_call({:stop}, _from, state) do

--- a/lib/exq/manager/server.ex
+++ b/lib/exq/manager/server.ex
@@ -39,7 +39,10 @@ defmodule Exq.Manager.Server do
 
     {:ok, localhost} = :inet.gethostname()
 
-    {:ok, stats} =  GenServer.start_link(Stats, {redis}, [])
+    stats = String.to_atom("#{name}_stats")
+    {:ok, _} =  Exq.Stats.Supervisor.start_link(
+      redis: redis,
+      name: stats)
 
     enqueuer = String.to_atom("#{name}_enqueuer")
     {:ok, _} =  Exq.Enqueuer.Supervisor.start_link(
@@ -149,7 +152,6 @@ defmodule Exq.Manager.Server do
   end
 
   def terminate(_reason, state) do
-    GenServer.call(state.stats, {:stop})
     :eredis.stop(state.redis)
     :ok
   end

--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -1,4 +1,5 @@
 defmodule Exq.Redis.Connection do
+  require Logger
 
   alias Exq.Support.Config
 
@@ -101,11 +102,12 @@ defmodule Exq.Redis.Connection do
     res
   end
 
-  def lpop!(redis, key) do
-    case q(redis, ["LPOP", key]) do
-      {:ok, :undefined} -> :none
-      {:ok, value} -> value
-    end
+  def lpop(redis, key) do
+    q(redis, ["LPOP", key])
+  end
+
+  def zadd(redis, set, score, member) do
+    q(redis, ["ZADD", set, score, member])
   end
 
   def zadd!(redis, set, score, member) do

--- a/lib/exq/stats/server.ex
+++ b/lib/exq/stats/server.ex
@@ -8,6 +8,8 @@ defmodule Exq.Stats.Server do
   alias Exq.Stats.Process
   require Logger
 
+  @default_name :exq_stats
+
   defmodule State do
     defstruct redis: nil
   end
@@ -20,14 +22,17 @@ defmodule Exq.Stats.Server do
 ## gen server callbacks
 ##===========================================================
 
-  def start_link(redis) do
-    GenServer.start_link(__MODULE__, {redis}, [])
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, @default_name)
+    GenServer.start_link(__MODULE__, [opts], [{:name, name}])
   end
 
   # These are the callbacks that GenServer.Behaviour will use
-  def init({redis}) do
-    {:ok, %State{redis: redis}}
+  def init([opts]) do
+    {:ok, %State{redis: Keyword.get(opts, :redis)}}
   end
+
+  def default_name, do: @default_name
 
   def handle_cast({:add_process, namespace, process}, state) do
     add_process(state.redis, namespace, process)

--- a/lib/exq/stats/supervisor.ex
+++ b/lib/exq/stats/supervisor.ex
@@ -1,0 +1,16 @@
+defmodule Exq.Stats.Supervisor do
+  use Supervisor
+
+  def start_link(opts \\ []) do
+    Supervisor.start_link(__MODULE__, [opts], name: String.to_atom("#{manager_name(opts)}_sup"))
+  end
+
+  def init([opts]) do
+    children = [worker(Exq.Stats.Server, [opts])]
+    supervise(children, strategy: :one_for_one, max_restarts: 20)
+  end
+
+  defp manager_name(opts) do
+    Keyword.get(opts, :name, Exq.Stats.Server.default_name)
+  end
+end

--- a/test/failure_scenarios_test.exs
+++ b/test/failure_scenarios_test.exs
@@ -1,0 +1,61 @@
+Code.require_file "test_helper.exs", __DIR__
+
+defmodule FailureScenariosTest do
+  use ExUnit.Case
+  use Timex
+  import ExqTestUtil
+
+  defmodule PerformWorker do
+    def perform do
+      send :exqtest, {:worked}
+    end
+  end
+
+  setup do
+    TestRedis.start
+    on_exit fn ->
+      wait
+      TestRedis.teardown
+    end
+    :ok
+  end
+
+  test "handle Redis connection lost on manager" do
+    {:ok, _} = Exq.start_link([name: :exq_f, port: 6555 ])
+
+    # Stop Redis and wait for a bit
+    TestRedis.stop
+    # Not ideal - but seems to be min time for manager to die past supervision
+    :timer.sleep(5000)
+
+    # Starting Redis again, things should be back to normal
+    TestRedis.start
+    wait_long
+    assert_exq_up(:exq_f)
+    Exq.stop(:exq_f)
+  end
+
+  test "handle Redis connection lost on enqueue" do
+    # Start Exq but don't listen to any queues
+    {:ok, _} = Exq.start_link([name: :exq_f, port: 6555])
+
+    # Stop Redis
+    TestRedis.stop
+    wait_long
+
+    # enqueue with redis stopped
+    enq_result = Exq.enqueue(:exq_f, "default", "FakeWorker", [])
+    assert enq_result ==  {:error, :no_connection}
+
+    enq_result = Exq.enqueue_at(:exq_f, "default", Time.now, ExqTest.PerformWorker, [])
+    assert enq_result ==  {:error, :no_connection}
+
+    # Starting Redis again and things should be back to normal
+    wait_long
+    TestRedis.start
+    wait_long
+
+    assert_exq_up(:exq_f)
+    Exq.stop(:exq_f)
+  end
+end

--- a/test/flaky_connection_test.exs
+++ b/test/flaky_connection_test.exs
@@ -5,6 +5,8 @@ defmodule FlakyConnectionTest do
   require Logger
   import ExqTestUtil
 
+  @moduletag :flakey_connection
+
   setup do
     TestRedis.setup
     on_exit fn ->

--- a/test/redis_test.exs
+++ b/test/redis_test.exs
@@ -57,13 +57,13 @@ defmodule Exq.RedisTest do
   end
 
   test "lpop empty" do
-    assert Connection.lpop!(:testredis, "bogus")  == :none
+    assert Connection.lpop(:testredis, "bogus")  == {:ok, :undefined}
   end
 
   test "rpush / lpop" do
     Connection.rpush!(:testredis, "akey", "avalue")
-    assert Connection.lpop!(:testredis, "akey")  == "avalue"
-    assert Connection.lpop!(:testredis, "akey")  == :none
+    assert Connection.lpop(:testredis, "akey")  == {:ok, "avalue"}
+    assert Connection.lpop(:testredis, "akey")  == {:ok, :undefined}
   end
 
   test "zadd / zcard / zrem" do


### PR DESCRIPTION
* Catch and handle exceptions related to Redis
* Take out this handling from JobQueue and bubble results up
* Manager back off in case of any Redis errors
* Enqueue to return errors in case of Redis issues

To be done:
* Long term plan is to break out each queue fetcher to a separate
GenServer so we can use BRPOPLPUSH, so this logic would be moved there.