### PR TITLE
Removed some Elixir compilation warnings

### DIFF
--- a/lib/exq/manager/server.ex
+++ b/lib/exq/manager/server.ex
@@ -94,17 +94,17 @@ defmodule Exq.Manager.Server do
     {:noreply, state, 10}
   end
 
-  def handle_call({:subscribe, queue}, from, state) do
+  def handle_call({:subscribe, queue}, _from, state) do
     updated_state = add_queue(state, queue)
     {:reply, :ok, updated_state,0}
   end
 
-  def handle_call({:subscribe, queue, concurrency}, from, state) do
+  def handle_call({:subscribe, queue, concurrency}, _from, state) do
     updated_state = add_queue(state, queue, concurrency)
     {:reply, :ok, updated_state,0}
   end
 
-  def handle_call({:unsubscribe, queue}, from, state) do
+  def handle_call({:unsubscribe, queue}, _from, state) do
     updated_state = remove_queue(state, queue)
     {:reply, :ok, updated_state,0}
   end
@@ -125,7 +125,7 @@ defmodule Exq.Manager.Server do
     {:noreply, state, 0}
   end
 
-  def handle_cast({:job_terminated, namespace, queue, job_json}, state) do
+  def handle_cast({:job_terminated, _namespace, queue, job_json}, state) do
     rescue_timeout(fn ->
       update_worker_count(state.work_table, queue, -1)
       JobQueue.remove_job_from_backup(state.redis, state.namespace, state.host, queue, job_json)
@@ -190,7 +190,7 @@ defmodule Exq.Manager.Server do
 
   def dispatch_job!(state, potential_job) do
     case potential_job do
-      {:ok, {:none, queue}} ->
+      {:ok, {:none, _queue}} ->
         {:ok, :none}
       {:ok, {job, queue}} ->
         dispatch_job!(state, job, queue)

--- a/lib/exq/manager/server.ex
+++ b/lib/exq/manager/server.ex
@@ -1,7 +1,6 @@
 defmodule Exq.Manager.Server do
   require Logger
   use GenServer
-  alias Exq.Stats.Server, as: Stats
   alias Exq.Enqueuer
   alias Exq.Redis.JobQueue
   alias Exq.Support.Config

--- a/lib/exq/manager/server.ex
+++ b/lib/exq/manager/server.ex
@@ -109,6 +109,15 @@ defmodule Exq.Manager.Server do
     {:reply, :ok, updated_state,0}
   end
 
+  def handle_call({:stop}, _from, state) do
+    { :stop, :normal, :ok, state }
+  end
+
+  def handle_call(_request, _from, state) do
+    Logger.error("UNKNOWN CALL")
+    {:reply, :unknown, state, 0}
+  end
+
   def handle_cast({:re_enqueue_backup, queue}, state) do
     rescue_timeout(fn ->
       JobQueue.re_enqueue_backup(state.redis, state.namespace, state.host, queue)
@@ -122,15 +131,6 @@ defmodule Exq.Manager.Server do
       JobQueue.remove_job_from_backup(state.redis, state.namespace, state.host, queue, job_json)
     end)
     {:noreply, state, 0}
-  end
-
-  def handle_call({:stop}, _from, state) do
-    { :stop, :normal, :ok, state }
-  end
-
-  def handle_call(_request, _from, state) do
-    Logger.error("UNKNOWN CALL")
-    {:reply, :unknown, state, 0}
   end
 
   def handle_cast(_request, state) do

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -78,7 +78,7 @@ defmodule Exq.Redis.JobQueue do
     enqueue_job_at(redis, namespace, job_json, jid, time, scheduled_queue_key(namespace))
   end
 
-  def enqueue_job_at(redis, namespace, job_json, jid, time, scheduled_queue) do
+  def enqueue_job_at(redis, _namespace, job_json, jid, time, scheduled_queue) do
     score = time_to_score(time)
     try do
       case Connection.zadd(redis, scheduled_queue, score, job_json) do
@@ -150,7 +150,7 @@ defmodule Exq.Redis.JobQueue do
     end)
   end
 
-  def scheduler_dequeue_requeue([], _redis, _namespace, _queues, schedule_queue, count), do: count
+  def scheduler_dequeue_requeue([], _redis, _namespace, _queues, _schedule_queue, count), do: count
   def scheduler_dequeue_requeue([job_json|t], redis, namespace, queues, schedule_queue, count) do
     if Connection.zrem!(redis, schedule_queue, job_json) == "1" do
       if Enum.count(queues) == 1 do

--- a/lib/exq/redis/job_stat.ex
+++ b/lib/exq/redis/job_stat.ex
@@ -5,9 +5,6 @@ defmodule Exq.Redis.JobStat do
   alias Exq.Support.Binary
   alias Exq.Redis.Connection
   alias Exq.Redis.JobQueue
-  alias Exq.Support.Json
-  alias Exq.Support.Job
-  alias Exq.Support.Process
 
   def record_processed(redis, namespace, _job) do
     time = DateFormat.format!(Date.universal, "%Y-%m-%d %T %z", :strftime)

--- a/lib/exq/redis/job_stat.ex
+++ b/lib/exq/redis/job_stat.ex
@@ -22,7 +22,7 @@ defmodule Exq.Redis.JobStat do
     {:ok, count}
   end
 
-  def record_failure(redis, namespace, error, _job) do
+  def record_failure(redis, namespace, _error, _job) do
     time = DateFormat.format!(Date.universal, "%Y-%m-%d %T %z", :strftime)
     date = DateFormat.format!(Date.universal, "%Y-%m-%d", :strftime)
 

--- a/lib/exq/stats/server.ex
+++ b/lib/exq/stats/server.ex
@@ -1,10 +1,8 @@
 defmodule Exq.Stats.Server do
   use GenServer
   use Timex
-  alias Exq.Redis.Connection
   alias Exq.Redis.JobQueue
   alias Exq.Redis.JobStat
-  alias Exq.Support.Json
   alias Exq.Support.Process
   require Logger
 

--- a/lib/exq/worker/server.ex
+++ b/lib/exq/worker/server.ex
@@ -36,9 +36,9 @@ defmodule Exq.Worker.Server do
     {:ok, process_info} = Stats.add_process(state.stats, state.namespace, self(), state.host, state.job_json)
     job = Exq.Support.Job.from_json(state.job_json)
     target = String.replace(job.class, "::", ".")
-    [mod | func_or_empty] = Regex.split(~r/\//, target)
+    [mod | _func_or_empty] = Regex.split(~r/\//, target)
     func = :perform
-    args = job.args
+    _args = job.args
     GenServer.cast(self, :dispatch)
     {:noreply, %{state | worker_module: String.to_atom("Elixir.#{mod}"),
                  worker_function: func, job: job, process_info: process_info } }


### PR DESCRIPTION
If you wish 😉

There are still two warnings when running `mix`:

```
lib/exq/redis/job_queue.ex:229: warning: function dequeue_random/3 is unused
```
should it be removed?

```
lib/exq/support/process.ex:1: warning: redefining module Exq.Support.Process
```
Looks like `Exq.Stats.Process` should exist:
```
$ ag Exq.Support.Process

lib/exq/stats/process.ex
1:defmodule Exq.Support.Process do

lib/exq/support/process.ex
1:defmodule Exq.Support.Process do
```