### PR TITLE
Add uuid to mix applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Exq.Mixfile do
   def application do
     [
       mod: { Exq, [] },
-      applications: [:logger, :tzdata, :redix, :timex]
+      applications: [:logger, :tzdata, :redix, :timex, :uuid]
     ]
   end
 


### PR DESCRIPTION
When running a compiled erlang release, rather than using mix, uuid won't be available unless it's in the mix applications list.