### PR TITLE
Allow the Redis connection to be setup via a URL

### DIFF
--- a/lib/exq/support/opts.ex
+++ b/lib/exq/support/opts.ex
@@ -24,15 +24,19 @@ defmodule Exq.Support.Opts do
   end
 
   def redis_opts(opts \\ []) do
-    host = opts[:host] || Config.get(:host, '127.0.0.1')
-    port = opts[:port] || Config.get(:port, 6379)
-    database = opts[:database] || Config.get(:database, 0)
-    password = opts[:password] || Config.get(:password)
+    redis_opts = if url = opts[:url] || Config.get(:url) do
+      url
+    else
+      host = opts[:host] || Config.get(:host, '127.0.0.1')
+      port = opts[:port] || Config.get(:port, 6379)
+      database = opts[:database] || Config.get(:database, 0)
+      password = opts[:password] || Config.get(:password)
+      [host: host, port: port, database: database, password: password]
+    end
     reconnect_on_sleep = opts[:reconnect_on_sleep] || Config.get(:reconnect_on_sleep, 100)
     timeout = opts[:redis_timeout] || Config.get(:redis_timeout, @default_timeout)
     if is_binary(host), do: host = String.to_char_list(host)
-    {[host: host, port: port, database: database, password: password],
-     [backoff: reconnect_on_sleep, timeout: timeout, name: opts[:redis]]}
+    {redis_opts, [backoff: reconnect_on_sleep, timeout: timeout, name: opts[:redis]]}
   end
 
   def redis_client_name(name) do

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -36,7 +36,6 @@ defmodule Exq.ConfigTest do
     assert redis_opts[:password] == 'password'
 
     Mix.Config.persist([exq: [password: "binary_password"]])
-
     {redis_opts, _} = Exq.Support.Opts.redis_opts
     assert redis_opts[:password] == "binary_password"
 

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -43,6 +43,9 @@ defmodule Exq.ConfigTest do
     {redis_opts, _} = Exq.Support.Opts.redis_opts
     assert redis_opts[:password] == nil
 
+    Mix.Config.persist([exq: [url: "redis_url"]])
+    {redis_opts, _} = Exq.Support.Opts.redis_opts
+    assert redis_opts == "redis_url"
   end
 
   test "conform_opts" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -97,7 +97,7 @@ defmodule TestRedis do
     try do
       Connection.flushdb! :testredis
     catch
-      :exit, {:timeout, info} -> nil
+      :exit, {:timeout, _info} -> nil
     end
   end
 


### PR DESCRIPTION
The URL takes precedence over the host, password, port and database connection options.