### PR TITLE
Run through linter and cleanup a few cases

### DIFF
--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -27,12 +27,14 @@ defmodule Exq.Redis.JobQueue do
   Find a current job by job id (but do not pop it)
   """
   def find_job(redis, namespace, jid, :scheduled) do
-    Connection.zrangebyscore!(redis, scheduled_queue_key(namespace))
-      |> find_job(jid)
+    redis
+    |> Connection.zrangebyscore!(scheduled_queue_key(namespace))
+    |> find_job(jid)
   end
   def find_job(redis, namespace, jid, queue) do
-    Connection.lrange!(redis, queue_key(namespace, queue))
-      |> find_job(jid)
+    redis
+    |> Connection.lrange!(queue_key(namespace, queue))
+    |> find_job(jid)
   end
   def find_job(jobs, jid) do
     finder = fn({j, _idx}) ->
@@ -167,7 +169,9 @@ defmodule Exq.Redis.JobQueue do
     case resp do
       {:error, reason} -> [{:error, reason}]
       {:ok, responses} ->
-        Enum.zip(queues, responses) |> Enum.reduce(0, fn({queue, response}, acc) ->
+        queues
+        |> Enum.zip(responses)
+        |> Enum.reduce(0, fn({queue, response}, acc) ->
           case response do
             jobs when is_list(jobs) ->
               deq_count = scheduler_dequeue_requeue(jobs, redis, namespace, queue, 0)

--- a/lib/exq/redis/job_stat.ex
+++ b/lib/exq/redis/job_stat.ex
@@ -56,8 +56,9 @@ defmodule Exq.Redis.JobStat do
   end
 
   def find_failed(redis, namespace, jid) do
-    Connection.zrange!(redis, JobQueue.full_key(namespace, "dead"), 0, -1)
-      |> JobQueue.find_job(jid)
+    redis
+    |> Connection.zrange!(JobQueue.full_key(namespace, "dead"), 0, -1)
+    |> JobQueue.find_job(jid)
   end
 
   def remove_queue(redis, namespace, queue) do

--- a/lib/exq/support/job.ex
+++ b/lib/exq/support/job.ex
@@ -27,7 +27,7 @@ defmodule Exq.Support.Job do
   end
 
   def to_json(job) do
-    Enum.into([
+    json = Enum.into([
       args: job.args,
       class: job.class,
       enqueued_at: job.enqueued_at,
@@ -40,6 +40,6 @@ defmodule Exq.Support.Job do
       queue: job.queue,
       retry: job.retry,
       retry_count: job.retry_count], HashDict.new)
-    Json.encode!(job)
+    Json.encode!(json)
   end
 end


### PR DESCRIPTION
Used [Credo](https://github.com/rrrene/credo) to do this.

I've found that the code is fairly clean already. :+1: 

One interesting part is in `lib/exq/support/job.ex`, `to_json` creates a HashDict but doesn't use it for converting to JSON.

(sidenote: my first elixir-based PR! :tada:)