### PR TITLE
Centralize configuration

### DIFF
--- a/lib/exq/enqueue_api.ex
+++ b/lib/exq/enqueue_api.ex
@@ -24,7 +24,7 @@ defmodule Exq.Enqueuer.EnqueueApi do
       * `{:error, reason}` if there was an error enqueueing job
       """
       def enqueue(pid, queue, worker, args) do
-        GenServer.call(pid, {:enqueue, queue, worker, args}, Config.get(:genserver_timeout, 5000))
+        GenServer.call(pid, {:enqueue, queue, worker, args}, Config.get(:genserver_timeout))
       end
       def enqueue(pid, from, queue, worker, args) do
         GenServer.cast(pid, {:enqueue, from, queue, worker, args})
@@ -41,7 +41,7 @@ defmodule Exq.Enqueuer.EnqueueApi do
         * `args` - Array of args to send to worker
       """
       def enqueue_at(pid, queue, time, worker, args) do
-        GenServer.call(pid, {:enqueue_at, queue, time, worker, args}, Config.get(:genserver_timeout, 5000))
+        GenServer.call(pid, {:enqueue_at, queue, time, worker, args}, Config.get(:genserver_timeout))
       end
       def enqueue_at(pid, from, queue, time, worker, args) do
         GenServer.cast(pid, {:enqueue_at, from, queue, time, worker, args})
@@ -58,7 +58,7 @@ defmodule Exq.Enqueuer.EnqueueApi do
         * `args` - Array of args to send to worker
       """
       def enqueue_in(pid, queue, offset, worker, args) do
-        GenServer.call(pid, {:enqueue_in, queue, offset, worker, args}, Config.get(:genserver_timeout, 5000))
+        GenServer.call(pid, {:enqueue_in, queue, offset, worker, args}, Config.get(:genserver_timeout))
       end
       def enqueue_in(pid, from, queue, offset, worker, args) do
         GenServer.cast(pid, {:enqueue_in, from, queue, offset, worker, args})

--- a/lib/exq/enqueuer/server.ex
+++ b/lib/exq/enqueuer/server.ex
@@ -44,7 +44,7 @@ defmodule Exq.Enqueuer.Server do
 
   def init(opts) do
     redis = opts[:redis] || Exq.Support.Opts.redis_client_name(opts[:name])
-    namespace = opts[:namespace] || Config.get(:namespace, "exq")
+    namespace = opts[:namespace] || Config.get(:namespace)
     state = %State{redis: redis, namespace: namespace}
     {:ok, state}
   end
@@ -231,7 +231,7 @@ defmodule Exq.Enqueuer.Server do
   end
 
   def server_name(name) do
-    unless name, do: name = Config.get(:name, Exq)
+    unless name, do: name = Config.get(:name)
     "#{name}.Enqueuer" |> String.to_atom
   end
 

--- a/lib/exq/enqueuer/supervisor.ex
+++ b/lib/exq/enqueuer/supervisor.ex
@@ -23,7 +23,7 @@ defmodule Exq.Enqueuer.Supervisor do
   end
 
   def supervisor_name(name) do
-    unless name, do: name = Exq.Support.Config.get(:name, Exq)
+    unless name, do: name = Exq.Support.Config.get(:name)
     "#{name}.Enqueuer.Sup" |> String.to_atom
   end
 

--- a/lib/exq/manager/server.ex
+++ b/lib/exq/manager/server.ex
@@ -349,7 +349,7 @@ defmodule Exq.Manager.Server do
     end
   end
 
-  defp server_name(nil), do: Config.get(:name, Exq)
+  defp server_name(nil), do: Config.get(:name)
   defp server_name(name), do: name
 
 end

--- a/lib/exq/middleware/server.ex
+++ b/lib/exq/middleware/server.ex
@@ -69,7 +69,7 @@ defmodule Exq.Middleware.Server do
   Returns middleware server name
   """
   def server_name(name) do
-    unless name, do: name = Exq.Support.Config.get(:name, Exq)
+    unless name, do: name = Exq.Support.Config.get(:name)
     "#{name}.Middleware.Server" |> String.to_atom
   end
 

--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -7,8 +7,6 @@ defmodule Exq.Redis.Connection do
 
   alias Exq.Support.Config
 
-  @default_timeout 5000
-
   def flushdb!(redis) do
     {:ok, res} = q(redis, ["flushdb"])
     res
@@ -148,11 +146,11 @@ defmodule Exq.Redis.Connection do
   end
 
   def q(redis, command) do
-    Redix.command(redis, command, [timeout: Config.get(:redis_timeout, @default_timeout)])
+    Redix.command(redis, command, [timeout: Config.get(:redis_timeout)])
   end
 
   def qp(redis, command) do
-    Redix.pipeline(redis, command, [timeout: Config.get(:redis_timeout, @default_timeout)])
+    Redix.pipeline(redis, command, [timeout: Config.get(:redis_timeout)])
   end
 
 end

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -20,9 +20,6 @@ defmodule Exq.Redis.JobQueue do
   alias Exq.Support.Config
   alias Exq.Support.Randomize
 
-  @default_max_retries 25
-  @default_queue "default"
-
   @doc """
   Find a current job by job id (but do not pop it)
   """
@@ -231,7 +228,7 @@ defmodule Exq.Redis.JobQueue do
 
   def retry_or_fail_job(redis, namespace, %{retry: true} = job, error) do
     retry_count = (job.retry_count || 0) + 1
-    max_retries = Config.get(:max_retries, @default_max_retries)
+    max_retries = Config.get(:max_retries)
 
     if (retry_count <= max_retries) do
       job = %{job |

--- a/lib/exq/scheduler/server.ex
+++ b/lib/exq/scheduler/server.ex
@@ -31,7 +31,7 @@ defmodule Exq.Scheduler.Server do
   end
 
   def server_name(name) do
-    unless name, do: name = Exq.Support.Config.get(:name, Exq)
+    unless name, do: name = Exq.Support.Config.get(:name)
     "#{name}.Scheduler" |> String.to_atom
    end
 

--- a/lib/exq/stats/server.ex
+++ b/lib/exq/stats/server.ex
@@ -52,7 +52,7 @@ defmodule Exq.Stats.Server do
   end
 
   def server_name(name) do
-    unless name, do: name = Exq.Support.Config.get(:name, Exq)
+    unless name, do: name = Exq.Support.Config.get(:name)
     "#{name}.Stats" |> String.to_atom
   end
 

--- a/lib/exq/support/config.ex
+++ b/lib/exq/support/config.ex
@@ -11,7 +11,13 @@ defmodule Exq.Support.Config do
     poll_timeout: 100,
     redis_timeout: 5000,
     genserver_timeout: 5000,
-    max_retries: 25
+    max_retries: 25,
+    middleware: [
+      Exq.Middleware.Stats,
+      Exq.Middleware.Job,
+      Exq.Middleware.Manager,
+      Exq.Middleware.Logger
+    ]
   }
 
   def get(key) do

--- a/lib/exq/support/config.ex
+++ b/lib/exq/support/config.ex
@@ -1,5 +1,24 @@
 defmodule Exq.Support.Config do
-  def get(key, fallback \\ nil) do
+  @default_config %{
+    name: Exq,
+    host: "127.0.0.1",
+    port: 6379,
+    namespace: "exq",
+    queues: ["default"],
+    scheduler_enable: true,
+    concurrency: 100,
+    scheduler_poll_timeout: 200,
+    poll_timeout: 100,
+    redis_timeout: 5000,
+    genserver_timeout: 5000,
+    max_retries: 25
+  }
+
+  def get(key) do
+    get(key, Map.get(@default_config, key))
+  end
+
+  def get(key, fallback) do
     Application.get_env(:exq, key, fallback)
   end
 end

--- a/lib/exq/support/opts.ex
+++ b/lib/exq/support/opts.ex
@@ -2,13 +2,11 @@ defmodule Exq.Support.Opts do
 
   alias Exq.Support.Config
 
-  @default_timeout 5000
-
   @doc """
    Return top supervisor's name default is Exq.Sup
   """
   def top_supervisor(name) do
-    unless name, do: name = Exq.Support.Config.get(:name, Exq)
+    unless name, do: name = Exq.Support.Config.get(:name)
     "#{name}.Sup" |> String.to_atom
   end
 
@@ -27,27 +25,27 @@ defmodule Exq.Support.Opts do
     redis_opts = if url = opts[:url] || Config.get(:url) do
       url
     else
-      host = opts[:host] || Config.get(:host, '127.0.0.1')
-      port = opts[:port] || Config.get(:port, 6379)
+      host = opts[:host] || Config.get(:host)
+      port = opts[:port] || Config.get(:port)
       database = opts[:database] || Config.get(:database, 0)
       password = opts[:password] || Config.get(:password)
       [host: host, port: port, database: database, password: password]
     end
     reconnect_on_sleep = opts[:reconnect_on_sleep] || Config.get(:reconnect_on_sleep, 100)
-    timeout = opts[:redis_timeout] || Config.get(:redis_timeout, @default_timeout)
+    timeout = opts[:redis_timeout] || Config.get(:redis_timeout)
     if is_binary(host), do: host = String.to_char_list(host)
     {redis_opts, [backoff: reconnect_on_sleep, timeout: timeout, name: opts[:redis]]}
   end
 
   def redis_client_name(name) do
-    unless name, do: name = Exq.Support.Config.get(:name, Exq)
+    unless name, do: name = Exq.Support.Config.get(:name)
     "#{name}.Redis.Client" |> String.to_atom
   end
 
   defp server_opts(opts) do
-    scheduler_enable = opts[:scheduler_enable] || Config.get(:scheduler_enable, true)
-    namespace = opts[:namespace] || Config.get(:namespace, "exq")
-    scheduler_poll_timeout = opts[:scheduler_poll_timeout] || Config.get(:scheduler_poll_timeout, 200)
+    scheduler_enable = opts[:scheduler_enable] || Config.get(:scheduler_enable)
+    namespace = opts[:namespace] || Config.get(:namespace)
+    scheduler_poll_timeout = opts[:scheduler_poll_timeout] || Config.get(:scheduler_poll_timeout)
     poll_timeout = opts[:poll_timeout] || Config.get(:poll_timeout, 50)
 
     enqueuer = Exq.Enqueuer.Server.server_name(opts[:name])
@@ -56,12 +54,11 @@ defmodule Exq.Support.Opts do
     workers_sup = Exq.Worker.Supervisor.supervisor_name(opts[:name])
     middleware = Exq.Middleware.Server.server_name(opts[:name])
 
-    queue_configs = opts[:queues] || Config.get(:queues, ["default"])
+    queue_configs = opts[:queues] || Config.get(:queues)
     per_queue_concurrency = opts[:concurrency] || Config.get(:concurrency, 10_000)
     queues = get_queues(queue_configs)
     concurrency = get_concurrency(queue_configs, per_queue_concurrency)
-    default_middleware = Config.get(:middleware, [Exq.Middleware.Stats, Exq.Middleware.Job, Exq.Middleware.Manager,
-    Exq.Middleware.Logger])
+    default_middleware = Config.get(:middleware)
 
     [scheduler_enable: scheduler_enable, namespace: namespace,
      scheduler_poll_timeout: scheduler_poll_timeout,workers_sup: workers_sup,

--- a/lib/exq/worker/supervisor.ex
+++ b/lib/exq/worker/supervisor.ex
@@ -14,7 +14,7 @@ defmodule Exq.Worker.Supervisor do
   end
 
   def supervisor_name(name) do
-    unless name, do: name = Exq.Support.Config.get(:name, Exq)
+    unless name, do: name = Exq.Support.Config.get(:name)
     "#{name}.Worker.Sup" |> String.to_atom
   end
 


### PR DESCRIPTION
This will close #163 

Copied configuration from `config.exs` to `lib/exq/support/config.ex` and made `Config.get/1` to fetch the corresponding value if fallback isn't given.
