### PR TITLE
Updates for Timex 2.0.0

### DIFF
--- a/lib/exq/middleware/logger.ex
+++ b/lib/exq/middleware/logger.ex
@@ -24,7 +24,7 @@ defmodule Exq.Middleware.Logger do
 
 
   defp delta(%Pipeline{assigns: assigns}) do
-    Time.diff(Time.now, assigns.started_at, :usecs)
+    Time.diff(Time.now, assigns.started_at, :microseconds)
   end
 
   defp log_context(%Pipeline{assigns: assigns}) do

--- a/lib/exq/redis/job_stat.ex
+++ b/lib/exq/redis/job_stat.ex
@@ -7,11 +7,12 @@ defmodule Exq.Redis.JobStat do
   require Logger
   use Timex
 
+  alias Timex.Format.DateTime.Formatter
   alias Exq.Support.Binary
   alias Exq.Redis.Connection
   alias Exq.Redis.JobQueue
 
-  def record_processed(redis, namespace, _job, current_date \\ Date.universal) do
+  def record_processed(redis, namespace, _job, current_date \\ DateTime.universal) do
     {time, date} = format_current_date(current_date)
 
     {:ok, [count, _, _, _]} = Connection.qp(redis,[
@@ -23,7 +24,7 @@ defmodule Exq.Redis.JobStat do
     {:ok, count}
   end
 
-  def record_failure(redis, namespace, _error, _job, current_date \\ Date.universal) do
+  def record_failure(redis, namespace, _error, _job, current_date \\ DateTime.universal) do
     {time, date} = format_current_date(current_date)
 
     {:ok, [count, _, _, _]} = Connection.qp(redis, [
@@ -114,7 +115,7 @@ defmodule Exq.Redis.JobStat do
 
   defp format_current_date(current_date) do
     format_fn = fn(format) ->
-      DateFormat.format!(current_date, format, :strftime)
+      Formatter.format!(current_date, format, :strftime)
     end
 
     {format_fn.("%Y-%m-%d %T %z"), format_fn.("%Y-%m-%d")}

--- a/lib/exq/stats/server.ex
+++ b/lib/exq/stats/server.ex
@@ -10,8 +10,11 @@ defmodule Exq.Stats.Server do
   """
   use GenServer
   use Timex
+
+  alias Timex.Format.DateTime.Formatter
   alias Exq.Redis.JobStat
   alias Exq.Support.Process
+
   require Logger
 
   defmodule State do
@@ -22,7 +25,10 @@ defmodule Exq.Stats.Server do
   Add in progress worker process
   """
   def add_process(stats, namespace, worker, host, job) do
-    process_info = %Process{pid: worker, host: host, job: job, started_at: DateFormat.format!(Date.universal, "{ISO}")}
+    process_info = %Process{pid: worker,
+                            host: host,
+                            job: job,
+                            started_at: Formatter.format!(DateTime.universal, "{ISO}")}
     GenServer.cast(stats, {:add_process, namespace, process_info})
     {:ok, process_info}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Exq.Mixfile do
       { :uuid, ">= 1.0.0" },
       { :redix, ">= 0.3.4"},
       { :poison, ">= 1.2.0 and < 2.0.0"},
-      { :timex, ">= 1.0.0" },
+      { :timex, "~> 2.0.0" },
       { :excoveralls, "~> 0.3", only: :test },
       { :flaky_connection, git: "https://github.com/hamiltop/flaky_connection.git", only: :test},
 

--- a/mix.lock
+++ b/mix.lock
@@ -19,6 +19,6 @@
   "ranch": {:hex, :ranch, "1.1.0"},
   "redix": {:hex, :redix, "0.3.4"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
-  "timex": {:hex, :timex, "1.0.0"},
+  "timex": {:hex, :timex, "2.0.0"},
   "tzdata": {:hex, :tzdata, "0.5.6"},
   "uuid": {:hex, :uuid, "1.0.1"}}

--- a/test/job_queue_test.exs
+++ b/test/job_queue_test.exs
@@ -99,17 +99,17 @@ defmodule JobQueueTest do
   test "scheduler_dequeue max_score" do
     JobQueue.enqueue_in(:testredis, "test", "default", 300, MyWorker, [])
     now = Time.now
-    time1 = Time.add(now, Time.from(140, :secs))
+    time1 = Time.add(now, Time.from(140, :seconds))
     JobQueue.enqueue_at(:testredis, "test", "default", time1, MyWorker, [])
-    time2 = Time.add(now, Time.from(150, :secs))
+    time2 = Time.add(now, Time.from(150, :seconds))
     JobQueue.enqueue_at(:testredis, "test", "default", time2, MyWorker, [])
-    time2a = Time.add(now, Time.from(151, :secs))
-    time2b = Time.add(now, Time.from(159, :secs))
-    time3 = Time.add(now, Time.from(160, :secs))
+    time2a = Time.add(now, Time.from(151, :seconds))
+    time2b = Time.add(now, Time.from(159, :seconds))
+    time3 = Time.add(now, Time.from(160, :seconds))
     JobQueue.enqueue_at(:testredis, "test", "default", time3, MyWorker, [])
-    time4 = Time.add(now, Time.from(160000001, :usecs))
+    time4 = Time.add(now, Time.from(160000001, :microseconds))
     JobQueue.enqueue_at(:testredis, "test", "default", time4, MyWorker, [])
-    time5 = Time.add(now, Time.from(300, :secs))
+    time5 = Time.add(now, Time.from(300, :seconds))
 
     api_state = %Exq.Api.Server.State{redis: :testredis, namespace: "test"}
     assert Exq.Api.Server.queue_size(api_state, "default") == 0

--- a/test/job_stat_test.exs
+++ b/test/job_stat_test.exs
@@ -36,8 +36,8 @@ defmodule JobStatTest do
   end
 
   test "show realtime statistics" do
-    {:ok, time1} = DateFormat.parse("2016-01-07T13:30:00+00", "{ISO}")
-    {:ok, time2} = DateFormat.parse("2016-01-07T14:05:15+00", "{ISO}")
+    {:ok, time1} = Timex.parse("2016-01-07T13:30:00+00", "{ISO}")
+    {:ok, time2} = Timex.parse("2016-01-07T14:05:15+00", "{ISO}")
 
     JobStat.record_processed(:testredis, "test", nil, time1)
     JobStat.record_processed(:testredis, "test", nil, time2)


### PR DESCRIPTION
- Timex 2.0 doesn't support `Date.universal` and is replaced with `DateTime.universal`
- DateTime formatter was moved and the DateFormat module no longer exists
- Cleans up a bunch of warnings about secs/seconds, usecs/microseconds

fixes #179