### PR TITLE
Allow poison 2.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule Exq.Mixfile do
     [
       { :uuid, ">= 1.0.0" },
       { :redix, ">= 0.3.4"},
-      { :poison, ">= 1.2.0 and < 2.0.0"},
+      { :poison, ">= 1.2.0 or ~> 2.0"},
       { :timex, ">= 2.0.0" },
       { :excoveralls, "~> 0.3", only: :test },
       { :flaky_connection, git: "https://github.com/hamiltop/flaky_connection.git", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -15,7 +15,7 @@
   "jsx": {:hex, :jsx, "2.6.2"},
   "mimerl": {:hex, :mimerl, "1.0.2"},
   "plug": {:hex, :plug, "1.0.2"},
-  "poison": {:hex, :poison, "1.5.0"},
+  "poison": {:hex, :poison, "2.1.0"},
   "ranch": {:hex, :ranch, "1.1.0"},
   "redix": {:hex, :redix, "0.3.4"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},

--- a/test/job_queue_test.exs
+++ b/test/job_queue_test.exs
@@ -145,7 +145,7 @@ defmodule JobQueueTest do
     assert jid != nil
 
     [{:ok, {job_str, _}}] = JobQueue.dequeue(:testredis, "test", @host, ["default"])
-    job = Poison.decode!(job_str, as: Exq.Support.Job)
+    job = Poison.decode!(job_str, as: %Exq.Support.Job{})
     assert job.jid == jid
   end
 


### PR DESCRIPTION
Hi,

I was trying to upgrade my app to Poison 2 and ran into a dependency issue.
The API used in `Exq.Support.Json` should work with both 1.x and 2.x, so I think
it is ok to relax the dependency.
I also updated the lock file to use 2.x in the tests, but let me know if you would rather
stick with 1.x there.

Thanks!