### PR TITLE
Fix `EnqueuerApi#enqueue_at` offset time units doc

### DIFF
--- a/lib/exq/enqueue_api.ex
+++ b/lib/exq/enqueue_api.ex
@@ -53,7 +53,7 @@ defmodule Exq.Enqueuer.EnqueueApi do
       Expected args:
         * `pid` - PID for Exq Manager or Enqueuer to handle this
         * `queue` - Name of queue to use
-        * offset - Offset in milliseconds in the future to enqueue
+        * `offset` - Offset in seconds in the future to enqueue
         * `worker` - Worker module to target
         * `args` - Array of args to send to worker
       """


### PR DESCRIPTION
Change time unit from milliseconds to seconds.

As we can see in `exq/lib/exq/redis/job_queue.ex:59`, the provided
offset is multiplied by `1_000_000` at treated as a value in
`microseconds`.

(I actually found out that by waiting 10 minutes for a job to process in
production :[ )