### PR TITLE
Fix possible race condition on startup

### DIFF
--- a/lib/exq/support/mode.ex
+++ b/lib/exq/support/mode.ex
@@ -25,11 +25,11 @@ defmodule Exq.Support.Mode do
   def children(:default, opts) do
     children = [
       worker(Exq.Middleware.Server, [opts]),
+      supervisor(Exq.Worker.Supervisor, [opts]),
       worker(Exq.Manager.Server, [opts]),
       worker(Exq.Stats.Server, [opts]),
       worker(Exq.Enqueuer.Server, [opts]),
-      worker(Exq.Api.Server, [opts]),
-      supervisor(Exq.Worker.Supervisor, [opts])
+      worker(Exq.Api.Server, [opts])
     ]
 
     if opts[:scheduler_enable] do


### PR DESCRIPTION
```
18:17:35.698 [error] GenServer Exq terminating
** (stop) exited in: GenServer.call(Exq.Worker.Sup, {:start_child, ["{\"retry\":5,\"queue\":\"email_notification\",\"backtrace\":true,\"class\":\"EmailService\",\"args\":[\"47e861f3-b531-4c3e-885d-209638be7736\",{\"order_id\":\"o2323\",\"merchant_id\":\"A0123123\",\"subject\":\"[testing] Notifikasi email valid 1\",\"from\":{\"name\":\"PATO\",\"email\":\"pato@veritrans.co.id\"},\"to\":[{\"name\":\"andri\",\"email\":\"ananthakumaran@gmail.com\"},{\"name\":\"ak\",\"email\":\"ananthakumaran+3@gmail.com\"}],\"cc\":[{\"name\":\"andri\",\"email\":\"ananthakumaran@gmail.com\"},{\"name\":\"ak\",\"email\":\"ananthakumaran+3@gmail.com\"}],\"bcc\":null,\"text_body\":\"Ini adalah isi email dengan format text.\",\"html_body\":\"<!DOCTYPE html PUBLIC \\\"-//W3C//DTD HTML 4.0 Transitional//EN\\\" \\\"http://www.w3.org/TR/REC-html40/loose.dtd\\\">\\n<html><body><h1>Ini adalah isi email dengan format HTML.</h1></body></html>\\n\",\"custom_field\":null},\"email_notification\"],\"jid\":\"3315bbf72c721e99cfb638ba\",\"enqueued_at\":1467636452.971734}", #PID<0.160.0>, "email_notification", 118823, Exq.Stats, "pato", "Ananthas-MacBook-Pro", Exq.Redis.Client, Exq.Middleware.Server]}, :infinity)
    ** (EXIT) no process
    (elixir) lib/gen_server.ex:596: GenServer.call/3
    (exq) lib/exq/manager/server.ex:271: Exq.Manager.Server.dispatch_job/3
    (exq) lib/exq/manager/server.ex:263: Exq.Manager.Server.dispatch_job/2
    (elixir) lib/enum.ex:1184: Enum."-map/2-lists^map/1-0-"/2
    (exq) lib/exq/manager/server.ex:230: anonymous fn/2 in Exq.Manager.Server.dequeue_and_dispatch/2
    (exq) lib/exq/manager/server.ex:324: Exq.Manager.Server.rescue_timeout/2
    (exq) lib/exq/manager/server.ex:206: Exq.Manager.Server.handle_info/2
    (stdlib) gen_server.erl:615: :gen_server.try_dispatch/4
Last message: :timeout
State: %Exq.Manager.Server.State{enqueuer: Exq.Enqueuer, host: "Ananthas-MacBook-Pro", middleware: Exq.Middleware.Server, namespace: "pato", pid: #PID<0.160.0>, poll_timeout: 50, queues: ["email_notification"], redis: Exq.Redis.Client, scheduler_poll_timeout: 200, stats: Exq.Stats, work_table: 118823, workers_sup: Exq.Worker.Sup}
```
This occurs consistently(atleast in my machine) if there are pending jobs in the queue.