### PR TITLE
Throttler integration

### DIFF
--- a/lib/exq/middleware/job.ex
+++ b/lib/exq/middleware/job.ex
@@ -31,7 +31,7 @@ defmodule Exq.Middleware.Job do
     pipeline
   end
 
-  defp remove_job_from_backup(%Pipeline{assigns: assigns} = pipeline) do
+  def remove_job_from_backup(%Pipeline{assigns: assigns} = pipeline) do
     JobQueue.remove_job_from_backup(assigns.redis, assigns.namespace, assigns.host, assigns.queue,
       assigns.job_json)
     pipeline

--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -74,6 +74,11 @@ defmodule Exq.Redis.Connection do
     res
   end
 
+  def sismember!(redis, set, member) do
+    {:ok, res} = q(redis, ["SISMEMBER", set, member])
+    res
+  end
+
   def lrange!(redis, list, range_start \\ "0", range_end \\ "-1") do
     {:ok, items} = q(redis, ["LRANGE", list, range_start, range_end])
     items
@@ -113,6 +118,11 @@ defmodule Exq.Redis.Connection do
 
   def zcard!(redis, set) do
     {:ok, count} = q(redis, ["ZCARD", set])
+    count
+  end
+
+  def zcount!(redis, set, min \\ "-inf", max \\ "+inf") do
+    {:ok, count} = q(redis, ["ZCOUNT", set, min, max])
     count
   end
 

--- a/lib/exq/worker/server.ex
+++ b/lib/exq/worker/server.ex
@@ -64,7 +64,11 @@ defmodule Exq.Worker.Server do
   def handle_cast(:work, state) do
     state = %{state | middleware_state: Middleware.all(state.middleware)}
     state = %{state | pipeline: before_work(state)}
-    GenServer.cast(self, :dispatch)
+    case state |> Map.fetch!(:pipeline) |> Map.get(:terminated, false) do
+      # case done to run the after hooks
+      true -> nil
+      _ -> GenServer.cast(self, :dispatch)
+    end
     {:noreply, state}
   end
 

--- a/test/redis_test.exs
+++ b/test/redis_test.exs
@@ -30,6 +30,14 @@ defmodule Exq.RedisTest do
     assert Connection.smembers!(:testredis, "theset") == ["amember"]
   end
 
+  test "sismember" do
+    _ = Connection.sadd!(:testredis, "theset", "amember")
+    _ = Connection.sadd!(:testredis, "theset", "anothermember")
+    assert 1 == Connection.sismember!(:testredis, "theset", "amember")
+    assert 1 == Connection.sismember!(:testredis, "theset", "anothermember")
+    assert 0 == Connection.sismember!(:testredis, "theset", "not_a_member")
+  end
+
   test "lpop empty" do
     assert Connection.lpop(:testredis, "bogus")  == {:ok, nil}
   end
@@ -68,6 +76,19 @@ defmodule Exq.RedisTest do
     assert Connection.zrem!(:testredis, "akey", "avalue") == 0
     assert Connection.zrem!(:testredis, "akey", "cvalue") == 1
     assert Connection.zrangebyscore!(:testredis, "akey", 0, "999999.999999") == []
+  end
+
+  test "zcount" do
+    assert Connection.zcount!(:testredis, "akey") == Connection.zcard!(:testredis, "akey")
+    assert Connection.zadd!(:testredis, "akey", "1", "avalue") == 1
+    assert Connection.zadd!(:testredis, "akey", "1", "bvalue") == 1
+    assert Connection.zadd!(:testredis, "akey", "2", "cvalue") == 1
+
+    assert Connection.zcount!(:testredis, "akey", "0", "1") == 2
+    assert Connection.zcount!(:testredis, "akey", "1", "1") == 2
+    assert Connection.zcount!(:testredis, "akey", "-inf", "+inf") == 3
+    assert Connection.zcount!(:testredis, "akey", "1", "(2") == 2
+    assert Connection.zcount!(:testredis, "akey", "(1", "2") == 1
   end
 
   test "flushdb" do


### PR DESCRIPTION
##### Base functions for Throttler middleware

- Add a new flag `terminated` in `Exq.Middleware.Pipeline` to halt the execution of the pipeline AND the worker
- Add `zcount!` and `sismember!` in `Exq.Redis.Connection` as utility function
- Add logic to handle `terminated` flag in pipeline in `Exq.Worker.Server`
- Expose `Exq.Middleware.Job.remove_job_from_backup/1` as public function instead of private
- Add tests for `terminated` flag as well as `zcount!` and `sismember!` in `Exq.Redis.Connection` module

Note: @akira I add a bit logic into Exq.Worker.Server to handle the termination of a job. The expected behaviour of this flag, when set to true, is to halt the execution of the pipeline AND prevent the job from getting dispatched. I haven't figured out a better way of getting the same behaviour. So, if you got any idea or concern regarding to the change, just ping me in Github and I am happy to discuss with you about it. Thank you so much for taking time reviewing it and I'm looking forward to hear from you!