### PR TITLE
Add hexfactor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Travis Build Status](https://img.shields.io/travis/akira/exq.svg)](https://travis-ci.org/akira/exq)
 [![Coveralls Coverage](https://img.shields.io/coveralls/akira/exq.svg)](https://coveralls.io/github/akira/exq)
 [![Hex.pm Version](https://img.shields.io/hexpm/v/exq.svg)](https://hex.pm/packages/exq)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/akira/exq.svg?branch=master)](https://beta.hexfaktor.org/github/akira/exq)
 
 Exq is a job processing library compatible with Resque / Sidekiq for the [Elixir](http://elixir-lang.org) language.
 * Exq uses Redis as a store for background processing jobs.


### PR DESCRIPTION
Brings more visibility into outdated dependencies on `README.md`:

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/akira/exq.svg?branch=master)](https://beta.hexfaktor.org/github/akira/exq) 🍺

https://beta.hexfaktor.org/github/akira/exq

It looks like repo's owner gotta sign up, so the service does monitor for deps updates.

