### PR TITLE
Provide ability to customize node ID

### DIFF
--- a/lib/exq/node_identifier/behaviour.ex
+++ b/lib/exq/node_identifier/behaviour.ex
@@ -1,0 +1,5 @@
+defmodule Exq.NodeIdentifier.Behaviour do
+  use Behaviour
+
+  @callback node_id(String.t) :: String.t
+end

--- a/lib/exq/node_identifier/hostname_identifier.ex
+++ b/lib/exq/node_identifier/hostname_identifier.ex
@@ -1,0 +1,7 @@
+defmodule Exq.NodeIdentifier.HostnameIdentifier do
+  @behaviour Exq.NodeIdentifier.Behaviour
+
+  def node_id(hostname) do
+    hostname
+  end
+end

--- a/lib/exq/support/config.ex
+++ b/lib/exq/support/config.ex
@@ -17,6 +17,7 @@ defmodule Exq.Support.Config do
     reconnect_on_sleep: 100,
     max_retries: 25,
     serializer: Exq.Serializers.JsonSerializer,
+    node_identifier: Exq.NodeIdentifier.HostnameIdentifier,
     middleware: [
       Exq.Middleware.Stats,
       Exq.Middleware.Job,
@@ -34,6 +35,11 @@ defmodule Exq.Support.Config do
   end
 
   def serializer do
-    get(:serializer, Exq.Serializers.JsonSerializer)
+    get(:serializer)
   end
+
+  def node_identifier do
+    get(:node_identifier)
+  end
+
 end

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -133,7 +133,7 @@ defmodule ApiTest do
     {:ok, jid} = Exq.enqueue_in(Exq, 'custom', 1000, Bogus, [])
     {:ok, jobs} = Exq.Api.scheduled_with_scores(Exq.Api)
     assert Enum.count(jobs) == 1
-    [{job, score}] = jobs
+    [{job, _score}] = jobs
     assert job.jid == jid
   end
 


### PR DESCRIPTION
This is used for backup and restore purposes when a node crashes. This provides
a behaviour that can be plugged in instead of using hostname.

Fixes #217 