### PR TITLE
Expose retry via Exq.Api

### DIFF
--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -196,4 +196,8 @@ defmodule Exq.Api do
   def realtime_stats(pid) do
     GenServer.call(pid, :realtime_stats)
   end
+
+  def retry_job(pid, jid) do
+    GenServer.call(pid, {:retry_job, jid})
+  end
 end

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -173,6 +173,12 @@ defmodule Exq.Api.Server do
     {:reply, {:ok, failures, successes}, state, 0}
   end
 
+  def handle_call({:retry_job, jid}, _from, state) do
+    {:ok, job} = JobQueue.find_job(state.redis, state.namespace, jid, :retry)
+    JobQueue.retry_job(state.redis, state.namespace, job)
+    {:reply, :ok, state, 0}
+  end
+
   def terminate(_reason, _state) do
     :ok
   end

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -229,6 +229,10 @@ defmodule Exq.Redis.JobQueue do
       Logger.info("Queueing job #{job.jid} to retry in #{offset} seconds")
       enqueue_job_at(redis, namespace, Job.encode(job), job.jid, time, retry_queue_key(namespace))
   end
+  def retry_job(redis, namespace, job) do
+    remove_retry(redis, namespace, job.jid)
+    enqueue(redis, namespace, Job.encode(job))
+  end
 
   def fail_job(redis, namespace, job, error) do
     job = %{job | failed_at: Time.unix_seconds, retry_count: job.retry_count || 0,

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -270,4 +270,13 @@ defmodule ApiTest do
     assert {:ok, [{_, "1"}], [{_, "1"}]} = Exq.Api.realtime_stats(Exq.Api)
   end
 
+  test "retry job" do
+    JobQueue.retry_job(:testredis, 'test', %Job{jid: "1234"}, 1, "this is an error")
+
+    Exq.Api.retry_job(Exq.Api, "1234")
+
+    assert {:ok, 0} = Exq.Api.retry_size(Exq.Api)
+    assert {:ok, job} = Exq.Api.find_job(Exq.Api, nil, "1234")
+    assert job.jid == "1234"
+  end
 end


### PR DESCRIPTION
To support https://github.com/akira/exq_ui/issues/5 I couldn't find any way in the current exposed API to retry a job immediately, so I had a go at adding the ability to immediately enqueue a retry, removing it from the retry queue.

I'm still pretty new to elixir so happy for feedback and to make adjustments.