### PR TITLE
Configurable node identifier. Use node_id instead of host

### DIFF
--- a/lib/exq/manager/server.ex
+++ b/lib/exq/manager/server.ex
@@ -76,7 +76,7 @@ defmodule Exq.Manager.Server do
        a single MULT RPOPLPUSH command issued to Redis with the targeted queue.
 
        This command atomicaly pops an item off the queue and stores the item in a backup queue.
-       The backup queue is keyed off the queue and host name, so each host would
+       The backup queue is keyed off the queue and node id, so each node would
        have their own backup queue.
 
        Note that we cannot use a blocking pop since BRPOPLPUSH (unlike BRPOP) is more
@@ -118,7 +118,7 @@ defmodule Exq.Manager.Server do
   @backoff_mult 10
 
   defmodule State do
-    defstruct redis: nil, stats: nil, enqueuer: nil, pid: nil, host: nil, namespace: nil, work_table: nil,
+    defstruct redis: nil, stats: nil, enqueuer: nil, pid: nil, node_id: nil, namespace: nil, work_table: nil,
               queues: nil, poll_timeout: nil, scheduler_poll_timeout: nil, workers_sup: nil,
               middleware: nil
   end
@@ -137,8 +137,6 @@ defmodule Exq.Manager.Server do
 ##===========================================================
 
   def init(opts) do
-    {:ok, localhost} = :inet.gethostname()
-
     work_table = setup_queues(opts)
 
     state = %State{work_table: work_table,
@@ -147,7 +145,7 @@ defmodule Exq.Manager.Server do
                    workers_sup: opts[:workers_sup],
                    enqueuer: opts[:enqueuer],
                    middleware: opts[:middleware],
-                   host:  to_string(localhost),
+                   node_id:  Config.node_identifier.node_id(),
                    namespace: opts[:namespace],
                    queues: opts[:queues],
                    pid: self(),
@@ -191,7 +189,7 @@ defmodule Exq.Manager.Server do
 
   def handle_cast({:re_enqueue_backup, queue}, state) do
     rescue_timeout(fn ->
-      JobQueue.re_enqueue_backup(state.redis, state.namespace, state.host, queue)
+      JobQueue.re_enqueue_backup(state.redis, state.namespace, state.node_id, queue)
     end)
     {:noreply, state, 0}
   end
@@ -224,7 +222,7 @@ defmodule Exq.Manager.Server do
   def dequeue_and_dispatch(state, []), do: {state, state.poll_timeout}
   def dequeue_and_dispatch(state, queues) do
     rescue_timeout({state, state.poll_timeout}, fn ->
-      jobs = Exq.Redis.JobQueue.dequeue(state.redis, state.namespace, state.host, queues)
+      jobs = Exq.Redis.JobQueue.dequeue(state.redis, state.namespace, state.node_id, queues)
 
       job_results = jobs |> Enum.map(fn(potential_job) -> dispatch_job(state, potential_job) end)
 
@@ -269,7 +267,7 @@ defmodule Exq.Manager.Server do
     {:ok, worker} = Exq.Worker.Supervisor.start_child(
       state.workers_sup,
       [job, state.pid, queue, state.work_table,
-       state.stats, state.namespace, state.host, state.redis, state.middleware])
+       state.stats, state.namespace, state.node_id, state.redis, state.middleware])
     Exq.Worker.Server.work(worker)
     update_worker_count(state.work_table, queue, 1)
   end

--- a/lib/exq/node_identifier/behaviour.ex
+++ b/lib/exq/node_identifier/behaviour.ex
@@ -1,5 +1,5 @@
 defmodule Exq.NodeIdentifier.Behaviour do
   use Behaviour
 
-  @callback node_id(String.t) :: String.t
+  @callback node_id() :: String.t
 end

--- a/lib/exq/node_identifier/hostname_identifier.ex
+++ b/lib/exq/node_identifier/hostname_identifier.ex
@@ -1,7 +1,8 @@
 defmodule Exq.NodeIdentifier.HostnameIdentifier do
   @behaviour Exq.NodeIdentifier.Behaviour
 
-  def node_id(hostname) do
-    hostname
+  def node_id do
+     {:ok, hostname} = :inet.gethostname()
+     to_string(hostname)
   end
 end


### PR DESCRIPTION
Refactor node identifier to manager, rename host to node_id

Helps with #217 