### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Side::Client.push('queue' => 'elixir_queue', 'class' => 'ElixirWorker', 'args' =
 
 ## Security
 
-By default, you Redis server could be open to the world. As by default, Redis comes with no password authentication, and some hosting companies leave that port accessible to the world.. This means that anyone can read data on the queue as well as pass data in to be run. Obviously this is not desired, please secure your Redis installation by following guides such as the [Digital Ocean Redis Security Guide](https://www.digitalocean.com/community/tutorials/how-to-secure-your-redis-installation-on-ubuntu-14-04).
+By default, your Redis server could be open to the world. As by default, Redis comes with no password authentication, and some hosting companies leave that port accessible to the world.. This means that anyone can read data on the queue as well as pass data in to be run. Obviously this is not desired, please secure your Redis installation by following guides such as the [Digital Ocean Redis Security Guide](https://www.digitalocean.com/community/tutorials/how-to-secure-your-redis-installation-on-ubuntu-14-04).
 
 
 ## Web UI:


### PR DESCRIPTION
`you Redis` -> `your Redis`