### PR TITLE
add max_retries options for per worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ To enqueue jobs:
 {:ok, ack} = Exq.enqueue(Exq, "default", MyWorker, ["arg1", "arg2"])
 
 {:ok, ack} = Exq.enqueue(Exq, "default", "MyWorker", ["arg1", "arg2"])
+
+## Don't retry job in per worker
+{:ok, ack} = Exq.enqueue(Exq, "default", MyWorker, ["arg1", "arg2"], max_retries: 0)
+## max_retries = 10, it will override :max_retries in config
+{:ok, ack} = Exq.enqueue(Exq, "default", MyWorker, ["arg1", "arg2"], max_retries: 10)
+
 ```
 In this example, `"arg1"` will get passed as the first argument to the `perform` method in your worker, `"arg2"` will be second argument, etc.
 

--- a/lib/exq/enqueue_api.ex
+++ b/lib/exq/enqueue_api.ex
@@ -10,6 +10,7 @@ defmodule Exq.Enqueuer.EnqueueApi do
     quote location: :keep do
       alias Exq.Support.Config
 
+      @default_options []
       @doc """
       Enqueue a job immediately.
 
@@ -18,16 +19,23 @@ defmodule Exq.Enqueuer.EnqueueApi do
         * `queue` - Name of queue to use
         * `worker` - Worker module to target
         * `args` - Array of args to send to worker
+        * `options` - job options, for example [max_retries:  `Integer`]
 
       Returns:
       * `{:ok, jid}` if the job was enqueued successfully, with `jid` = Job ID.
       * `{:error, reason}` if there was an error enqueueing job
       """
-      def enqueue(pid, queue, worker, args) do
-        GenServer.call(pid, {:enqueue, queue, worker, args}, Config.get(:genserver_timeout))
+      def enqueue(pid, queue, worker, args), do: enqueue(pid, queue, worker, args, @default_options)
+
+      def enqueue(pid, from, queue, worker, args) when is_pid(from) do
+        enqueue(pid, from, queue, worker, args, @default_options)
       end
-      def enqueue(pid, from, queue, worker, args) do
-        GenServer.cast(pid, {:enqueue, from, queue, worker, args})
+      def enqueue(pid, queue, worker, args, options) do
+        GenServer.call(pid, {:enqueue, queue, worker, args, options}, Config.get(:genserver_timeout))
+      end
+
+      def enqueue(pid, from, queue, worker, args, options) do
+        GenServer.cast(pid, {:enqueue, from, queue, worker, args, options})
       end
 
       @doc """
@@ -39,12 +47,20 @@ defmodule Exq.Enqueuer.EnqueueApi do
         * `time` - Time to enqueue
         * `worker` - Worker module to target
         * `args` - Array of args to send to worker
+        * `options` - job options, for example [max_retries:  `Integer`]
+
       """
-      def enqueue_at(pid, queue, time, worker, args) do
-        GenServer.call(pid, {:enqueue_at, queue, time, worker, args}, Config.get(:genserver_timeout))
+      def enqueue_at(pid, queue, time, worker, args), do: enqueue_at(pid, queue, time, worker, args, @default_options)
+
+      def enqueue_at(pid, from, queue, time, worker, args) when is_pid(from) do
+        enqueue_at(pid, from, queue, time, worker, args, @default_options)
       end
-      def enqueue_at(pid, from, queue, time, worker, args) do
-        GenServer.cast(pid, {:enqueue_at, from, queue, time, worker, args})
+      def enqueue_at(pid, queue, time, worker, args, options) do
+        GenServer.call(pid, {:enqueue_at, queue, time, worker, args, options}, Config.get(:genserver_timeout))
+      end
+
+      def enqueue_at(pid, from, queue, time, worker, args, options) do
+        GenServer.cast(pid, {:enqueue_at, from, queue, time, worker, args, options})
       end
 
       @doc """
@@ -56,12 +72,20 @@ defmodule Exq.Enqueuer.EnqueueApi do
         * `offset` - Offset in seconds in the future to enqueue
         * `worker` - Worker module to target
         * `args` - Array of args to send to worker
+        * `options` - job options, for example [max_retries:  `Integer`]
+
       """
-      def enqueue_in(pid, queue, offset, worker, args) do
-        GenServer.call(pid, {:enqueue_in, queue, offset, worker, args}, Config.get(:genserver_timeout))
+      def enqueue_in(pid, queue, offset, worker, args), do: enqueue_in(pid, queue, offset, worker, args, @default_options)
+
+      def enqueue_in(pid, from, queue, offset, worker, args)when is_pid(from) do
+        enqueue_in(pid, from, queue, offset, worker, args, @default_options)
       end
-      def enqueue_in(pid, from, queue, offset, worker, args) do
-        GenServer.cast(pid, {:enqueue_in, from, queue, offset, worker, args})
+      def enqueue_in(pid, queue, offset, worker, args, options) do
+        GenServer.call(pid, {:enqueue_in, queue, offset, worker, args, options}, Config.get(:genserver_timeout))
+      end
+
+      def enqueue_in(pid, from, queue, offset, worker, args, options) do
+        GenServer.cast(pid, {:enqueue_in, from, queue, offset, worker, args, options})
       end
     end
   end

--- a/lib/exq/enqueuer/server.ex
+++ b/lib/exq/enqueuer/server.ex
@@ -35,36 +35,36 @@ defmodule Exq.Enqueuer.Server do
     {:ok, %State{redis: opts[:redis], namespace: opts[:namespace]}}
   end
 
-  def handle_cast({:enqueue, from, queue, worker, args}, state) do
-    response = JobQueue.enqueue(state.redis, state.namespace, queue, worker, args)
+  def handle_cast({:enqueue, from, queue, worker, args, options}, state) do
+    response = JobQueue.enqueue(state.redis, state.namespace, queue, worker, args, options)
     GenServer.reply(from, response)
     {:noreply, state}
   end
 
-  def handle_cast({:enqueue_at, from, queue, time, worker, args}, state) do
-    response = JobQueue.enqueue_at(state.redis, state.namespace, queue, time, worker, args)
+  def handle_cast({:enqueue_at, from, queue, time, worker, args, options}, state) do
+    response = JobQueue.enqueue_at(state.redis, state.namespace, queue, time, worker, args, options)
     GenServer.reply(from, response)
     {:noreply, state}
   end
 
-  def handle_cast({:enqueue_in, from, queue, offset, worker, args}, state) do
-    response = JobQueue.enqueue_in(state.redis, state.namespace, queue, offset, worker, args)
+  def handle_cast({:enqueue_in, from, queue, offset, worker, args, options}, state) do
+    response = JobQueue.enqueue_in(state.redis, state.namespace, queue, offset, worker, args, options)
     GenServer.reply(from, response)
     {:noreply, state}
   end
 
-  def handle_call({:enqueue, queue, worker, args}, _from, state) do
-    response = JobQueue.enqueue(state.redis, state.namespace, queue, worker, args)
+  def handle_call({:enqueue, queue, worker, args, options}, _from, state) do
+    response = JobQueue.enqueue(state.redis, state.namespace, queue, worker, args, options)
     {:reply, response, state}
   end
 
-  def handle_call({:enqueue_at, queue, time, worker, args}, _from, state) do
-    response = JobQueue.enqueue_at(state.redis, state.namespace, queue, time, worker, args)
+  def handle_call({:enqueue_at, queue, time, worker, args, options}, _from, state) do
+    response = JobQueue.enqueue_at(state.redis, state.namespace, queue, time, worker, args, options)
     {:reply, response, state}
   end
 
-  def handle_call({:enqueue_in, queue, offset, worker, args}, _from, state) do
-    response = JobQueue.enqueue_in(state.redis, state.namespace, queue, offset, worker, args)
+  def handle_call({:enqueue_in, queue, offset, worker, args, options}, _from, state) do
+    response = JobQueue.enqueue_in(state.redis, state.namespace, queue, offset, worker, args, options)
     {:reply, response, state}
   end
 
@@ -79,3 +79,4 @@ defmodule Exq.Enqueuer.Server do
     "#{name}.Enqueuer" |> String.to_atom
   end
 end
+

--- a/lib/exq/manager/server.ex
+++ b/lib/exq/manager/server.ex
@@ -157,18 +157,18 @@ defmodule Exq.Manager.Server do
     {:ok, state, 0}
   end
 
-  def handle_call({:enqueue, queue, worker, args}, from, state) do
-    Enqueuer.enqueue(state.enqueuer, from, queue, worker, args)
+  def handle_call({:enqueue, queue, worker, args, options}, from, state) do
+    Enqueuer.enqueue(state.enqueuer, from, queue, worker, args, options)
     {:noreply, state, 10}
   end
 
-  def handle_call({:enqueue_at, queue, time, worker, args}, from, state) do
-    Enqueuer.enqueue_at(state.enqueuer, from, queue, time, worker, args)
+  def handle_call({:enqueue_at, queue, time, worker, args, options}, from, state) do
+    Enqueuer.enqueue_at(state.enqueuer, from, queue, time, worker, args, options)
     {:noreply, state, 10}
   end
 
-  def handle_call({:enqueue_in, queue, offset, worker, args}, from, state) do
-    Enqueuer.enqueue_in(state.enqueuer, from, queue, offset, worker, args)
+  def handle_call({:enqueue_in, queue, offset, worker, args, options}, from, state) do
+    Enqueuer.enqueue_in(state.enqueuer, from, queue, offset, worker, args, options)
     {:noreply, state, 10}
   end
 

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -19,8 +19,8 @@ defmodule Exq.Redis.JobQueue do
   alias Exq.Support.Randomize
   alias Exq.Support.Time
 
-  def enqueue(redis, namespace, queue, worker, args) do
-    {jid, job_serialized} = to_job_serialized(queue, worker, args)
+  def enqueue(redis, namespace, queue, worker, args, options) do
+    {jid, job_serialized} = to_job_serialized(queue, worker, args, options)
     case enqueue(redis, namespace, queue, job_serialized) do
       :ok    -> {:ok, jid}
       other  -> other
@@ -54,12 +54,12 @@ defmodule Exq.Redis.JobQueue do
     end
   end
 
-  def enqueue_in(redis, namespace, queue, offset, worker, args) when is_integer(offset) do
+  def enqueue_in(redis, namespace, queue, offset, worker, args, options) when is_integer(offset) do
     time = Time.offset_from_now(offset)
-    enqueue_at(redis, namespace, queue, time, worker, args)
+    enqueue_at(redis, namespace, queue, time, worker, args, options)
   end
-  def enqueue_at(redis, namespace, queue, time, worker, args) do
-    {jid, job_serialized} = to_job_serialized(queue, worker, args)
+  def enqueue_at(redis, namespace, queue, time, worker, args, options) do
+    {jid, job_serialized} = to_job_serialized(queue, worker, args, options)
     enqueue_job_at(redis, namespace, job_serialized, jid, time, scheduled_queue_key(namespace))
   end
 
@@ -195,10 +195,7 @@ defmodule Exq.Redis.JobQueue do
     full_key(namespace, "dead")
   end
 
-  def retry_or_fail_job(redis, namespace, %{retry: true} = job, error) do
-    retry_or_fail_job(redis, namespace, job, error, Config.get(:max_retries))
-  end
-  def retry_or_fail_job(redis, namespace, %{retry: retry} = job, error) when is_integer(retry) do
+  def retry_or_fail_job(redis, namespace, %{retry: retry} = job, error) when is_integer(retry) and retry > 0 do
     retry_or_fail_job(redis, namespace, job, error, retry)
   end
   def retry_or_fail_job(redis, namespace, job, error) do
@@ -355,18 +352,19 @@ defmodule Exq.Redis.JobQueue do
     {:ok, found_job}
   end
 
-  def to_job_serialized(queue, worker, args) do
-    to_job_serialized(queue, worker, args, Time.unix_seconds)
+  def to_job_serialized(queue, worker, args, options) do
+    to_job_serialized(queue, worker, args, options, Time.unix_seconds)
   end
-  def to_job_serialized(queue, worker, args, enqueued_at) when is_atom(worker) do
-    to_job_serialized(queue, to_string(worker), args, enqueued_at)
+  def to_job_serialized(queue, worker, args, options, enqueued_at) when is_atom(worker) do
+    to_job_serialized(queue, to_string(worker), args, options, enqueued_at)
   end
-  def to_job_serialized(queue, "Elixir." <> worker, args, enqueued_at) do
-    to_job_serialized(queue, worker, args, enqueued_at)
+  def to_job_serialized(queue, "Elixir." <> worker, args, options, enqueued_at) do
+    to_job_serialized(queue, worker, args, options, enqueued_at)
   end
-  def to_job_serialized(queue, worker, args, enqueued_at) do
+  def to_job_serialized(queue, worker, args, options, enqueued_at) do
     jid = UUID.uuid4
-    job = Enum.into([{:queue, queue}, {:retry, true}, {:class, worker}, {:args, args}, {:jid, jid}, {:enqueued_at, enqueued_at}], HashDict.new)
+    retry = Keyword.get_lazy(options, :max_retries, fn() -> Config.get(:max_retries) end)
+    job = Enum.into([{:queue, queue}, {:retry, retry}, {:class, worker}, {:args, args}, {:jid, jid}, {:enqueued_at, enqueued_at}], HashDict.new)
     {jid, Config.serializer.encode!(job)}
   end
 end

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -83,7 +83,7 @@ defmodule ExqTest do
     Process.register(self, :exqtest)
 
     # enqueue and dequeue - this should now be in backup queue
-    JobQueue.enqueue(:testredis, "test", "queue", ExqTest.PerformWorker, [])
+    JobQueue.enqueue(:testredis, "test", "queue", ExqTest.PerformWorker, [], [])
     JobQueue.dequeue(:testredis, "test", host, ["queue"])
 
     # make sure jobs were requeued from backup queue

--- a/test/performance_test.exs
+++ b/test/performance_test.exs
@@ -23,7 +23,7 @@ defmodule PerformanceTest do
   test "test to_job_serialized performance" do
     started = :os.timestamp
     max_timeout_ms = 1_000
-    for _ <- 1..1000, do: Exq.Redis.JobQueue.to_job_serialized("default", PerformanceTest.Worker, ["keep_on_trucking"])
+    for _ <- 1..1000, do: Exq.Redis.JobQueue.to_job_serialized("default", PerformanceTest.Worker, ["keep_on_trucking"], max_retries: 10)
     elapsed_ms = :timer.now_diff(:os.timestamp, started) / 1_000
     Logger.debug "to_job_serialized performance test took #{elapsed_ms / 1_000} secs"
     assert elapsed_ms < max_timeout_ms


### PR DESCRIPTION
**Usage**
```ex
## Don't assign options, it's will using `:max_retries` in config.
{:ok, ack} = Exq.enqueue(Exq, "default", "MyWorker", ["arg1", "arg2"])
## this worker will using `max_retries = 10`, ignore `:max_retries` in config
{:ok, ack} = Exq.enqueue(Exq, "default", "MyWorker", ["arg1", "arg2"], max_retries: 10)
## disable retry job
{:ok, ack} = Exq.enqueue(Exq, "default", "MyWorker", ["arg1", "arg2"], max_retries: 0)
```
Limit `Exq.Support.Job.retry` only be `Integer`(no boolean).

https://github.com/akira/exq/issues/215
#224 
