### PR TITLE
Flush stats on interval using Redis batch API

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -18,4 +18,6 @@ config :exq,
   genserver_timeout: 5000,
   test_with_local_redis: true,
   max_retries: 0,
+  stats_flush_interval: 5,
+  stats_batch_size: 1,
   middleware: [Exq.Middleware.Stats, Exq.Middleware.Job, Exq.Middleware.Manager]

--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -162,4 +162,8 @@ defmodule Exq.Redis.Connection do
     Redix.pipeline(redis, command, [timeout: Config.get(:redis_timeout)])
   end
 
+  def qp!(redis, command) do
+    Redix.pipeline!(redis, command, [timeout: Config.get(:redis_timeout)])
+  end
+
 end

--- a/lib/exq/support/config.ex
+++ b/lib/exq/support/config.ex
@@ -16,6 +16,8 @@ defmodule Exq.Support.Config do
     shutdown_timeout: 5000,
     reconnect_on_sleep: 100,
     max_retries: 25,
+    stats_flush_interval: 1000,
+    stats_batch_size: 2000,
     serializer: Exq.Serializers.JsonSerializer,
     node_identifier: Exq.NodeIdentifier.HostnameIdentifier,
     middleware: [


### PR DESCRIPTION
Stats updates are currently being sent to Redis one at a time. This causes a situation
where stats updates can fall behind other parts of the system and cause memory to be eaten up.
This commit changes stats to flush batches of updates at a time. This allows the stats to
keep up with other parts of the system and update Redis more efficiently.

#122 #231 