### PR TITLE
Cleanup for Elixir 1.4

### DIFF
--- a/lib/exq.ex
+++ b/lib/exq.ex
@@ -10,7 +10,7 @@ defmodule Exq do
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do
-    start_link
+    start_link()
   end
 
   # Exq methods

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -27,156 +27,156 @@ defmodule Exq.Api.Server do
 
   def handle_call(:processes, _from, state) do
     processes = JobStat.processes(state.redis, state.namespace)
-    {:reply, {:ok, processes}, state, 0}
+    {:reply, {:ok, processes}, state}
   end
 
   def handle_call(:busy, _from, state) do
     count = JobStat.busy(state.redis, state.namespace)
-    {:reply, {:ok, count}, state, 0}
+    {:reply, {:ok, count}, state}
   end
 
   def handle_call({:stats, key}, _from, state) do
     count = JobStat.get_count(state.redis, state.namespace, key)
-    {:reply, {:ok, count}, state, 0}
+    {:reply, {:ok, count}, state}
   end
 
   def handle_call({:stats, key, date}, _from, state) do
     count = JobStat.get_count(state.redis, state.namespace, "#{key}:#{date}")
-    {:reply, {:ok, count}, state, 0}
+    {:reply, {:ok, count}, state}
   end
 
   def handle_call(:queues, _from, state) do
     queues = JobQueue.list_queues(state.redis, state.namespace)
-    {:reply, {:ok, queues}, state, 0}
+    {:reply, {:ok, queues}, state}
   end
 
   def handle_call(:failed, _from, state) do
    jobs = JobQueue.failed(state.redis, state.namespace)
-   {:reply, {:ok, jobs}, state, 0}
+   {:reply, {:ok, jobs}, state}
   end
 
   def handle_call(:retries, _from, state) do
    jobs = JobQueue.scheduled_jobs(state.redis, state.namespace, "retry")
-   {:reply, {:ok, jobs}, state, 0}
+   {:reply, {:ok, jobs}, state}
   end
 
   def handle_call(:jobs, _from, state) do
     jobs = JobQueue.jobs(state.redis, state.namespace)
-    {:reply, {:ok, jobs}, state, 0}
+    {:reply, {:ok, jobs}, state}
   end
   def handle_call({:jobs, :scheduled}, _from, state) do
     jobs = JobQueue.scheduled_jobs(state.redis, state.namespace, "schedule")
-    {:reply, {:ok, jobs}, state, 0}
+    {:reply, {:ok, jobs}, state}
   end
   def handle_call({:jobs, :scheduled_with_scores}, _from, state) do
     jobs = JobQueue.scheduled_jobs_with_scores(state.redis, state.namespace, "schedule")
-    {:reply, {:ok, jobs}, state, 0}
+    {:reply, {:ok, jobs}, state}
   end
   def handle_call({:jobs, queue}, _from, state) do
     jobs = JobQueue.jobs(state.redis, state.namespace, queue)
-    {:reply, {:ok, jobs}, state, 0}
+    {:reply, {:ok, jobs}, state}
   end
 
   def handle_call(:queue_size, _from, state) do
     sizes = JobQueue.queue_size(state.redis, state.namespace)
-    {:reply, {:ok, sizes}, state, 0}
+    {:reply, {:ok, sizes}, state}
   end
   def handle_call({:queue_size, queue}, _from, state) do
     size = JobQueue.queue_size(state.redis, state.namespace, queue)
-    {:reply, {:ok, size}, state, 0}
+    {:reply, {:ok, size}, state}
   end
 
   def handle_call(:scheduled_size, _from, state) do
     size = JobQueue.scheduled_size(state.redis, state.namespace)
-    {:reply, {:ok, size}, state, 0}
+    {:reply, {:ok, size}, state}
   end
 
   def handle_call(:retry_size, _from, state) do
     size = JobQueue.retry_size(state.redis, state.namespace)
-    {:reply, {:ok, size}, state, 0}
+    {:reply, {:ok, size}, state}
   end
 
   def handle_call(:failed_size, _from, state) do
     size = JobQueue.failed_size(state.redis, state.namespace)
-    {:reply, {:ok, size}, state, 0}
+    {:reply, {:ok, size}, state}
   end
 
   def handle_call({:find_failed, jid}, _from, state) do
     {:ok, job} = JobStat.find_failed(state.redis, state.namespace, jid)
-    {:reply, {:ok, job}, state, 0}
+    {:reply, {:ok, job}, state}
   end
 
   def handle_call({:find_job, queue, jid}, _from, state) do
     response = JobQueue.find_job(state.redis, state.namespace, jid, queue)
-    {:reply, response, state, 0}
+    {:reply, response, state}
   end
 
   def handle_call({:find_scheduled, jid}, _from, state) do
     {:ok, job} = JobQueue.find_job(state.redis, state.namespace, jid, :scheduled)
-    {:reply, {:ok, job}, state, 0}
+    {:reply, {:ok, job}, state}
   end
 
   def handle_call({:find_retry, jid}, _from, state) do
     {:ok, job} = JobQueue.find_job(state.redis, state.namespace, jid, :retry)
-    {:reply, {:ok, job}, state, 0}
+    {:reply, {:ok, job}, state}
   end
 
   def handle_call({:remove_queue, queue}, _from, state) do
     JobStat.remove_queue(state.redis, state.namespace, queue)
-    {:reply, :ok, state, 0}
+    {:reply, :ok, state}
   end
 
   def handle_call({:remove_job, queue, jid}, _from, state) do
     JobQueue.remove_job(state.redis, state.namespace, queue, jid)
-    {:reply, :ok, state, 0}
+    {:reply, :ok, state}
   end
 
 
   def handle_call({:remove_retry, jid}, _from, state) do
     JobQueue.remove_retry(state.redis, state.namespace, jid)
-    {:reply, :ok, state, 0}
+    {:reply, :ok, state}
   end
 
   def handle_call({:remove_scheduled, jid}, _from, state) do
     JobQueue.remove_scheduled(state.redis, state.namespace, jid)
-    {:reply, :ok, state, 0}
+    {:reply, :ok, state}
   end
 
   def handle_call({:remove_failed, jid}, _from, state) do
     JobStat.remove_failed(state.redis, state.namespace, jid)
-    {:reply, :ok, state, 0}
+    {:reply, :ok, state}
   end
 
 
   def handle_call(:clear_failed, _from, state) do
     JobStat.clear_failed(state.redis, state.namespace)
-    {:reply, :ok, state, 0}
+    {:reply, :ok, state}
   end
 
   def handle_call(:clear_processes, _from, state) do
     JobStat.clear_processes(state.redis, state.namespace)
-    {:reply, :ok, state, 0}
+    {:reply, :ok, state}
   end
 
   def handle_call(:clear_scheduled, _from, state) do
     JobQueue.delete_queue(state.redis, state.namespace, "schedule")
-    {:reply, :ok, state, 0}
+    {:reply, :ok, state}
   end
 
   def handle_call(:clear_retries, _from, state) do
     JobQueue.delete_queue(state.redis, state.namespace, "retry")
-    {:reply, :ok, state, 0}
+    {:reply, :ok, state}
   end
 
   def handle_call(:realtime_stats, _from, state) do
     {:ok, failures, successes} = JobStat.realtime_stats(state.redis, state.namespace)
-    {:reply, {:ok, failures, successes}, state, 0}
+    {:reply, {:ok, failures, successes}, state}
   end
 
   def handle_call({:retry_job, jid}, _from, state) do
     {:ok, job} = JobQueue.find_job(state.redis, state.namespace, jid, :retry)
     JobQueue.retry_job(state.redis, state.namespace, job)
-    {:reply, :ok, state, 0}
+    {:reply, :ok, state}
   end
 
   def terminate(_reason, _state) do

--- a/lib/exq/manager/server.ex
+++ b/lib/exq/manager/server.ex
@@ -286,7 +286,7 @@ defmodule Exq.Manager.Server do
     work_table = :ets.new(:work_table, [:set, :public])
     Enum.each(opts[:concurrency], fn (queue_concurrency) ->
       :ets.insert(work_table, queue_concurrency)
-      GenServer.cast(self, {:re_enqueue_backup, elem(queue_concurrency, 0)})
+      GenServer.cast(self(), {:re_enqueue_backup, elem(queue_concurrency, 0)})
     end)
     work_table
   end
@@ -294,7 +294,7 @@ defmodule Exq.Manager.Server do
   defp add_queue(state, queue, concurrency \\ Config.get(:concurrency)) do
     queue_concurrency = {queue, concurrency, 0}
     :ets.insert(state.work_table, queue_concurrency)
-    GenServer.cast(self, {:re_enqueue_backup, queue})
+    GenServer.cast(self(), {:re_enqueue_backup, queue})
     updated_queues = [queue | state.queues]
     %{state | queues: updated_queues}
   end

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -364,7 +364,7 @@ defmodule Exq.Redis.JobQueue do
   def to_job_serialized(queue, worker, args, options, enqueued_at) do
     jid = UUID.uuid4
     retry = Keyword.get_lazy(options, :max_retries, fn() -> Config.get(:max_retries) end)
-    job = Enum.into([{:queue, queue}, {:retry, retry}, {:class, worker}, {:args, args}, {:jid, jid}, {:enqueued_at, enqueued_at}], HashDict.new)
+    job = %{queue: queue, retry: retry, class: worker, args: args, jid: jid, enqueued_at: enqueued_at}
     {jid, Config.serializer.encode!(job)}
   end
 end

--- a/lib/exq/scheduler/server.ex
+++ b/lib/exq/scheduler/server.ex
@@ -43,7 +43,7 @@ defmodule Exq.Scheduler.Server do
     state = %State{redis: opts[:redis], namespace: opts[:namespace],
       queues: opts[:queues], scheduler_poll_timeout: opts[:scheduler_poll_timeout]}
 
-    start_timeout(self)
+    start_timeout(self())
 
     {:ok, state}
   end

--- a/lib/exq/serializers/json_serializer.ex
+++ b/lib/exq/serializers/json_serializer.ex
@@ -20,18 +20,18 @@ defmodule Exq.Serializers.JsonSerializer do
   def decode_job(serialized) do
     deserialized = decode!(serialized)
     %Exq.Support.Job{
-      args: Dict.get(deserialized, "args"),
-      class: Dict.get(deserialized, "class"),
-      enqueued_at: Dict.get(deserialized, "enqueued_at"),
-      error_message: Dict.get(deserialized, "error_message"),
-      error_class: Dict.get(deserialized, "error_class"),
-      failed_at: Dict.get(deserialized, "failed_at"),
-      finished_at: Dict.get(deserialized, "finished_at"),
-      jid: Dict.get(deserialized, "jid"),
-      processor: Dict.get(deserialized, "processor"),
-      queue: Dict.get(deserialized, "queue"),
-      retry: Dict.get(deserialized, "retry"),
-      retry_count: Dict.get(deserialized, "retry_count")}
+      args: Map.get(deserialized, "args"),
+      class: Map.get(deserialized, "class"),
+      enqueued_at: Map.get(deserialized, "enqueued_at"),
+      error_message: Map.get(deserialized, "error_message"),
+      error_class: Map.get(deserialized, "error_class"),
+      failed_at: Map.get(deserialized, "failed_at"),
+      finished_at: Map.get(deserialized, "finished_at"),
+      jid: Map.get(deserialized, "jid"),
+      processor: Map.get(deserialized, "processor"),
+      queue: Map.get(deserialized, "queue"),
+      retry: Map.get(deserialized, "retry"),
+      retry_count: Map.get(deserialized, "retry_count")}
   end
 
   def encode_job(job) do
@@ -55,10 +55,10 @@ defmodule Exq.Serializers.JsonSerializer do
   def decode_process(serialized) do
     deserialized = decode!(serialized)
     %Exq.Support.Process{
-      pid: Dict.get(deserialized, "pid"),
-      host: Dict.get(deserialized, "host"),
-      job: Dict.get(deserialized, "job"),
-      started_at: Dict.get(deserialized, "started_at")
+      pid: Map.get(deserialized, "pid"),
+      host: Map.get(deserialized, "host"),
+      job: Map.get(deserialized, "job"),
+      started_at: Map.get(deserialized, "started_at")
     }
   end
 
@@ -68,7 +68,7 @@ defmodule Exq.Serializers.JsonSerializer do
       pid: formatted_pid,
       host: process.host,
       job: process.job,
-      started_at: process.started_at], HashDict.new)
+      started_at: process.started_at], Map.new)
 
     encode!(deserialized)
   end

--- a/lib/exq/support/time.ex
+++ b/lib/exq/support/time.ex
@@ -2,19 +2,19 @@ defmodule Exq.Support.Time do
   import DateTime, only: [utc_now: 0, to_unix: 2, from_unix!: 2]
 
   def offset_from_now(offset) do
-    now_micro_sec = utc_now |> to_unix(:microseconds)
+    now_micro_sec = utc_now() |> to_unix(:microseconds)
     now = now_micro_sec
 
     from_unix!(round(now + offset * 1_000_000), :microseconds)
   end
 
-  def time_to_score(time \\ utc_now) do
+  def time_to_score(time \\ utc_now()) do
     time
     |> unix_seconds
     |> Float.to_string
   end
 
-  def unix_seconds(time \\ utc_now) do
+  def unix_seconds(time \\ utc_now()) do
     to_unix(time, :microseconds) / 1_000_000.0
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Exq.Mixfile do
       description: """
       Exq is a job processing library compatible with Resque / Sidekiq for the Elixir language.
       """,
-      deps: deps,
+      deps: deps(),
       test_coverage: [tool: ExCoveralls]
     ]
   end

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -10,7 +10,7 @@ defmodule ApiTest do
     TestRedis.setup
     Exq.start_link
     on_exit fn ->
-      wait
+      wait()
       TestRedis.teardown
     end
     :ok
@@ -42,7 +42,7 @@ defmodule ApiTest do
 
   test "busy processes when processing" do
     Exq.enqueue(Exq, 'custom', Bogus, [])
-    JobStat.add_process(:testredis, "test", %Process{pid: self})
+    JobStat.add_process(:testredis, "test", %Process{pid: self()})
     assert {:ok, 1} = Exq.Api.busy(Exq.Api)
   end
 
@@ -65,9 +65,9 @@ defmodule ApiTest do
   end
 
   test "processes with data" do
-    JobStat.add_process(:testredis, "test", %Process{pid: self})
+    JobStat.add_process(:testredis, "test", %Process{pid: self()})
     assert {:ok, [processes]} = Exq.Api.processes(Exq.Api)
-    my_pid_str = to_string(:erlang.pid_to_list(self))
+    my_pid_str = to_string(:erlang.pid_to_list(self()))
     assert %Process{pid: ^my_pid_str} = processes
   end
 

--- a/test/flaky_connection_test.exs
+++ b/test/flaky_connection_test.exs
@@ -21,7 +21,7 @@ defmodule FlakyConnectionTest do
 
   test "redis_timeout allows for higher latency" do
     Application.start(:ranch)
-    conn = FlakyConnection.start(redis_host, redis_port)
+    conn = FlakyConnection.start(redis_host(), redis_port())
 
     #Needs to be x2 latency + ~10
     Mix.Config.persist([exq: [redis_timeout: 2010]])
@@ -39,7 +39,7 @@ defmodule FlakyConnectionTest do
 
   test "redis_timeout higher than 5000 without genserver_timeout" do
     Application.start(:ranch)
-    conn = FlakyConnection.start(redis_host, redis_port)
+    conn = FlakyConnection.start(redis_host(), redis_port())
 
     #Needs to be x2 latency + ~10
     Mix.Config.persist([exq: [redis_timeout: 11010]])
@@ -63,7 +63,7 @@ defmodule FlakyConnectionTest do
 
   test "redis_timeout higher than 5000 with genserver_timeout" do
     Application.start(:ranch)
-    conn = FlakyConnection.start(redis_host, redis_port)
+    conn = FlakyConnection.start(redis_host(), redis_port())
 
     #redis_timeout needs to be x2 latency + ~10
     #genserver_timeout needs to be x2 latency + ~30

--- a/test/middleware_test.exs
+++ b/test/middleware_test.exs
@@ -130,7 +130,7 @@ defmodule MiddlewareTest do
   end
 
   setup do
-    Process.register(self, :middlewaretest)
+    Process.register(self(), :middlewaretest)
     {:ok, middleware} = GenServer.start_link(Middleware, [])
     {:ok, middleware: middleware}
   end
@@ -217,7 +217,7 @@ defmodule MiddlewareTest do
 
     pid = Process.whereis(Middleware)
     Process.exit(pid, :kill)
-    wait
+    wait()
 
     assert Middleware.all(Middleware) == chain
   end

--- a/test/performance_test.exs
+++ b/test/performance_test.exs
@@ -54,7 +54,7 @@ defmodule PerformanceTest do
     assert count == 0
     assert elapsed_ms < max_timeout_ms
     # let stats finish
-    wait_long
+    wait_long()
     stop_process(sup)
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -35,7 +35,7 @@ defmodule ExqTestUtil do
 
   def assert_exq_up(exq) do
     my_pid = String.to_atom(UUID.uuid4)
-    Process.register(self, my_pid)
+    Process.register(self(), my_pid)
     {:ok, _} = Exq.enqueue(exq, "default", "ExqTestUtil.SendWorker", [my_pid])
     ExUnit.Assertions.assert_receive {:worked}
     Process.unregister(my_pid)
@@ -87,9 +87,9 @@ defmodule TestRedis do
   end
 
   def setup do
-    {:ok, redis} = Redix.start_link([host: redis_host, port: redis_port])
+    {:ok, redis} = Redix.start_link([host: redis_host(), port: redis_port()])
     Process.register(redis, :testredis)
-    flush_all
+    flush_all()
     :ok
   end
 
@@ -104,7 +104,7 @@ defmodule TestRedis do
   def teardown do
     if !Process.whereis(:testredis) do
       # For some reason at the end of test the link is down, before we actually stop and unregister?
-      {:ok, redis} = Redix.start_link([host: redis_host, port: redis_port])
+      {:ok, redis} = Redix.start_link([host: redis_host(), port: redis_port()])
       Process.register(redis, :testredis)
     end
     Process.unregister(:testredis)

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -27,7 +27,7 @@ defmodule WorkerTest do
 
   defmodule SuicideWorker do
     def perform do
-      Process.exit(self, :kill)
+      Process.exit(self(), :kill)
     end
   end
 
@@ -94,7 +94,7 @@ defmodule WorkerTest do
   end
 
   def start_worker({class, args}) do
-    Process.register(self, :workertest)
+    Process.register(self(), :workertest)
     job = "{ \"queue\": \"default\", \"class\": \"#{class}\", \"args\": #{args} }"
 
     work_table = :ets.new(:work_table, [:set, :public])


### PR DESCRIPTION
* Parentheses for method calls
* Deprecated Dict
* Unecessary timeout for api