### PR TITLE
Cleanup process stats on boot

### DIFF
--- a/lib/exq/redis/job_stat.ex
+++ b/lib/exq/redis/job_stat.ex
@@ -58,6 +58,14 @@ defmodule Exq.Redis.JobStat do
     :ok
   end
 
+  def cleanup_processes(redis, namespace, host) do
+    Connection.smembers!(redis, JobQueue.full_key(namespace, "processes"))
+    |> Enum.map(fn(serialized) -> {Process.decode(serialized), serialized} end)
+    |> Enum.filter(fn({process, _}) -> process.host == host end)
+    |> Enum.each(fn({process, serialized}) -> remove_process(redis, namespace, process, serialized) end)
+    :ok
+  end
+
   def busy(redis, namespace) do
     Connection.scard!(redis, JobQueue.full_key(namespace, "processes"))
   end


### PR DESCRIPTION
When a node dies, stats are not cleaned up and workers can appear busy. To fix this,
cleanup stats for a host on boot.
Fixes #235 / #227