### PR TITLE
Fixes 1.4.2 Float.to_string/2 warning

### DIFF
--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -356,7 +356,7 @@ defmodule Exq.Redis.JobQueue do
     to_job_serialized(queue, worker, args, options, Time.unix_seconds)
   end
   def to_job_serialized(queue, worker, args, options, enqueued_at) when is_atom(worker) do
-    to_job_serialized(queue, to_string(worker), args, options, enqueued_at)
+    to_job_serialized(queue, :erlang.float_to_binary(worker), args, options, enqueued_at)
   end
   def to_job_serialized(queue, "Elixir." <> worker, args, options, enqueued_at) do
     to_job_serialized(queue, worker, args, options, enqueued_at)


### PR DESCRIPTION
After starting to use Elixir v1.4.2 I started to see this warning:

```
warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead
  (elixir) lib/float.ex:414: Float.to_string/2
  (exq) lib/exq/redis/job_queue.ex:131: Exq.Redis.JobQueue.scheduler_dequeue/2
  (exq) lib/exq/scheduler/server.ex:68: Exq.Scheduler.Server.dequeue/1
  (exq) lib/exq/scheduler/server.ex:56: Exq.Scheduler.Server.handle_info/2
  (stdlib) gen_server.erl:601: :gen_server.try_dispatch/4
```

It makes iex impossible to use. Would this fix to avoid getting the warning work for you @akira ?