### PR TITLE
Allow option to not start Exq on startup

### DIFF
--- a/lib/exq.ex
+++ b/lib/exq.ex
@@ -4,6 +4,7 @@ defmodule Exq do
 
   import Exq.Support.Opts, only: [top_supervisor: 1]
   alias Exq.Worker.Metadata
+  alias Exq.Support.Config
 
   # Mixin Enqueue API
   use Exq.Enqueuer.EnqueueApi
@@ -11,7 +12,12 @@ defmodule Exq do
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do
-    start_link()
+    if Config.get(:start_on_application) do
+      start_link()
+    else
+      # Don't start Exq
+      Supervisor.start_link([], strategy: :one_for_one)
+    end
   end
 
   # Exq methods

--- a/lib/exq/support/config.ex
+++ b/lib/exq/support/config.ex
@@ -22,6 +22,7 @@ defmodule Exq.Support.Config do
     serializer: Exq.Serializers.JsonSerializer,
     node_identifier: Exq.NodeIdentifier.HostnameIdentifier,
     backoff: Exq.Backoff.SidekiqDefault,
+    start_on_application: true,
     middleware: [
       Exq.Middleware.Stats,
       Exq.Middleware.Job,


### PR DESCRIPTION
This is useful when it is better to put it on Phoenix or other supervisor
explicitly. In that case, we can set it to not start automatically via this config.

#255 