### PR TITLE
Allow {:system, varname} format for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ For Elixir 1.2 or older, you will need to use Exq version 0.7.2 in hex, and you 
 
 ### Configuration:
 
-By default, Exq will use configuration from your config.exs file.  You can use this
-to configure your Redis host, port, password, as well as namespace (which helps isolate the data in Redis). If you would like to specify your options as a redis url, that is also an option using the `url` config key (in which case you would not need to pass the other redis options).
+By default, Exq will use configuration from your config.exs file.  You can use this to configure your Redis host, port, password, as well as namespace (which helps isolate the data in Redis). If you would like to specify your options as a redis url, that is also an option using the `url` config key (in which case you would not need to pass the other redis options).
+
+Configuration options may optionally be given in the `{:system, "VARNAME"}` format, which will resolve to the runtime environment value.
 
 Other options include:
 * The `queues` list specifies which queues Exq will listen to for new jobs.

--- a/lib/exq/support/coercion.ex
+++ b/lib/exq/support/coercion.ex
@@ -1,0 +1,25 @@
+defmodule Exq.Support.Coercion do
+  @moduledoc false
+
+  def to_integer(value) when is_integer(value) do
+    value
+  end
+
+  def to_integer(binary) when is_binary(binary) do
+    binary
+    |> Integer.parse()
+    |> case do
+      {integer, ""} ->
+        integer
+
+      _ ->
+        raise ArgumentError,
+          message: "Failed to parse #{inspect(binary)} into an integer."
+    end
+  end
+
+  def to_integer(value) do
+    raise ArgumentError,
+      message: "Failed to parse #{inspect(value)} into an integer."
+  end
+end

--- a/lib/exq/support/config.ex
+++ b/lib/exq/support/config.ex
@@ -36,7 +36,10 @@ defmodule Exq.Support.Config do
   end
 
   def get(key, fallback) do
-    Application.get_env(:exq, key, fallback)
+    case Application.get_env(:exq, key, fallback) do
+      {:system, varname} -> System.get_env(varname)
+      value -> value
+    end
   end
 
   def serializer do

--- a/lib/exq/support/opts.ex
+++ b/lib/exq/support/opts.ex
@@ -1,5 +1,6 @@
 defmodule Exq.Support.Opts do
 
+  alias Exq.Support.Coercion
   alias Exq.Support.Config
 
   @doc """
@@ -27,8 +28,8 @@ defmodule Exq.Support.Opts do
       url
     else
       host = opts[:host] || Config.get(:host)
-      port = coerce_integer(opts[:port] || Config.get(:port))
-      database = coerce_integer(opts[:database] || Config.get(:database))
+      port = Coercion.to_integer(opts[:port] || Config.get(:port))
+      database = Coercion.to_integer(opts[:database] || Config.get(:database))
       password = opts[:password] || Config.get(:password)
       [host: host, port: port, database: database, password: password]
     end
@@ -40,21 +41,6 @@ defmodule Exq.Support.Opts do
   def redis_client_name(name) do
     name = name || Config.get(:name)
     "#{name}.Redis.Client" |> String.to_atom
-  end
-
-  defp coerce_integer(value) when is_integer(value) do
-    value
-  end
-
-  defp coerce_integer(binary) when is_binary(binary) do
-    case Integer.parse(binary) do
-      {integer, ""} -> integer
-      _ -> raise("Failed to parse #{inspect(binary)} into an integer.")
-    end
-  end
-
-  defp coerce_integer(value) do
-    raise("Failed to parse #{inspect(value)} into an integer.")
   end
 
   defp server_opts(:default, opts) do

--- a/lib/exq/support/opts.ex
+++ b/lib/exq/support/opts.ex
@@ -27,8 +27,8 @@ defmodule Exq.Support.Opts do
       url
     else
       host = opts[:host] || Config.get(:host)
-      port = opts[:port] || Config.get(:port)
-      database = opts[:database] || Config.get(:database)
+      port = coerce_integer(opts[:port] || Config.get(:port))
+      database = coerce_integer(opts[:database] || Config.get(:database))
       password = opts[:password] || Config.get(:password)
       [host: host, port: port, database: database, password: password]
     end
@@ -40,6 +40,21 @@ defmodule Exq.Support.Opts do
   def redis_client_name(name) do
     name = name || Config.get(:name)
     "#{name}.Redis.Client" |> String.to_atom
+  end
+
+  defp coerce_integer(value) when is_integer(value) do
+    value
+  end
+
+  defp coerce_integer(binary) when is_binary(binary) do
+    case Integer.parse(binary) do
+      {integer, ""} -> integer
+      _ -> raise("Failed to parse #{inspect(binary)} into an integer.")
+    end
+  end
+
+  defp coerce_integer(value) do
+    raise("Failed to parse #{inspect(value)} into an integer.")
   end
 
   defp server_opts(:default, opts) do

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -8,7 +8,12 @@ defmodule Exq.ConfigTest do
   end
 
   setup do
-    on_exit fn -> ExqTestUtil.reset_config end
+    env = System.get_env
+
+    on_exit fn ->
+      ExqTestUtil.reset_env(env)
+      ExqTestUtil.reset_config
+    end
   end
 
   test "Mix.Config should change the host." do
@@ -48,6 +53,15 @@ defmodule Exq.ConfigTest do
     Mix.Config.persist([exq: [url: {:system, "REDIS_URL"}]])
     {redis_opts, _} = Exq.Support.Opts.redis_opts
     assert redis_opts == "redis_url"
+  end
+
+  test "Raises an ArgumentError when supplied with an invalid port" do
+    Mix.Config.persist([exq: [port: {:system, "REDIS_PORT"}]])
+    System.put_env("REDIS_PORT", "invalid integer")
+
+    assert_raise(ArgumentError, fn ->
+      Exq.Support.Opts.redis_opts
+    end)
   end
 
   test "redis_opts" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -23,6 +23,12 @@ defmodule ExqTestUtil do
 
   def redis_port do
     Exq.Support.Config.get(:port)
+    |> case do
+      port when is_binary(port) ->
+        String.to_integer(port)
+      value ->
+        value
+    end
   end
 
   import ExUnit.Assertions

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,8 @@
 defmodule TestStats do
   alias Exq.Redis.Connection
   alias Exq.Redis.JobQueue
+  alias Exq.Support.Coercion
+  alias Exq.Support.Config
 
   def processed_count(redis, namespace) do
     count = Connection.get!(redis, JobQueue.full_key(namespace, "stat:processed"))
@@ -17,18 +19,17 @@ defmodule ExqTestUtil do
   @timeout 20
   @long_timeout 100
 
+  alias Exq.Support.Coercion
+  alias Exq.Support.Config
+
   def redis_host do
-    Exq.Support.Config.get(:host)
+    Config.get(:host)
   end
 
   def redis_port do
-    Exq.Support.Config.get(:port)
-    |> case do
-      port when is_binary(port) ->
-        String.to_integer(port)
-      value ->
-        value
-    end
+    :port
+    |> Config.get()
+    |> Coercion.to_integer()
   end
 
   import ExUnit.Assertions
@@ -36,6 +37,18 @@ defmodule ExqTestUtil do
   defmodule SendWorker do
     def perform(pid) do
       send String.to_atom(pid), {:worked}
+    end
+  end
+
+  def reset_env(previous_env) do
+    # Restore all previous values
+    System.put_env(previous_env)
+
+    # Remove any newly added keys
+    for {key, _} <- System.get_env do
+      unless Map.has_key?(previous_env, key) do
+        System.delete_env(key)
+      end
     end
   end
 
@@ -77,17 +90,18 @@ end
 defmodule TestRedis do
   import ExqTestUtil
   alias Exq.Redis.Connection
+  alias Exq.Support.Config
 
   #TODO: Automate config
   def start do
-    unless Exq.Support.Config.get(:test_with_local_redis) == false do
+    unless Config.get(:test_with_local_redis) == false do
       [] = :os.cmd('redis-server test/test-redis.conf')
       :timer.sleep(100)
     end
   end
 
   def stop do
-    unless Exq.Support.Config.get(:test_with_local_redis) == false do
+    unless Config.get(:test_with_local_redis) == false do
       [] = :os.cmd('redis-cli -p 6555 shutdown')
     end
   end


### PR DESCRIPTION
Would love to get Exq supporting the `{:system, "VARNAME"}` format for runtime config...

Thoughts?

-- EDIT --

If you don't like the `{:system, ""}` approach, there are others:

* Exq can specify a fallback environment variable for URL (not from config)
* Exq can provide an [on_init callback similar to Phoenix](https://github.com/phoenixframework/phoenix/blob/7fbf4fc0567a3276c978b434c4f0c658228af276/lib/phoenix/endpoint.ex#L63-L80) to update config when the application starts.
* Exq can [rely less on compile-time config and more on arguments](https://elixirforum.com/t/mix-config-evolutions/4423/19)

If you think you'd merge this, I can add additional tests for when the environment variable is an invalid value (which is why coveralls says the code coverage went down)