### PR TITLE
Re-enqueue backup jobs to head of queue, atomically, using Lua script

### DIFF
--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -128,10 +128,6 @@ defmodule Exq.Redis.Connection do
     q(redis, ["LPOP", key])
   end
 
-  def rpoplpush(redis, key, backup) do
-    q(redis, ["RPOPLPUSH", key, backup])
-  end
-
   def zadd(redis, set, score, member) do
     q(redis, ["ZADD", set, score, member])
   end


### PR DESCRIPTION
Currently, jobs that are re-enqueued from the backup queue are placed at the end of the queue, just like failed jobs. This is unexpected behavior to most -- one would assume that, if you kill and restart a background-job runner, it will "pick up where it left off" by immediately resuming the same jobs it was working on when the node died.

Implementing this using plain Redis commands is impossible, given that there is no command like `LPOPLPUSH` or `RPOPRPUSH`. But the Redis `EVAL` command can be used to achieve the same result.

As written, the Lua script in this PR optimizes for low Redis memory overhead rather than speed, popping and pushing one element at a time rather than retrieving entire sets. I felt that this made sense, given that the size of a given backup queue is not usually that large (e.g. < 10000 elements), and that this script will only be evaluated once at node startup, and once for each dynamic queue creation.