### PR TITLE
Add an api to list all subscriptions(active queues)

### DIFF
--- a/lib/exq.ex
+++ b/lib/exq.ex
@@ -46,6 +46,14 @@ defmodule Exq do
   end
 
   @doc """
+  List all subscriptions(active queues)
+    * `pid` - PID for Exq Manager or Enqueuer to handle this
+  """
+  def subscriptions(pid) do
+    GenServer.call(pid, :subscriptions)
+  end
+
+  @doc """
   Subscribe to a queue - ie. listen to queue for jobs
     * `pid` - PID for Exq Manager or Enqueuer to handle this
     * `queue` - Name of queue

--- a/lib/exq/manager/server.ex
+++ b/lib/exq/manager/server.ex
@@ -182,6 +182,10 @@ defmodule Exq.Manager.Server do
     {:noreply, state, 10}
   end
 
+  def handle_call(:subscriptions, _from, state) do
+    {:reply, {:ok, state.queues}, state, 0}
+  end
+
   def handle_call({:subscribe, queue}, _from, state) do
     updated_state = add_queue(state, queue)
     {:reply, :ok, updated_state, 0}

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -218,7 +218,7 @@ defmodule ExqTest do
     {:ok, sup} = Exq.start_link(queues: ["q1"])
     :ok = Exq.subscribe(Exq, "q2")
 
-    assert {:ok, ["q1", "q2"]} = Exq.subscriptions(Exq)
+    assert {:ok, ["q2", "q1"]} = Exq.subscriptions(Exq)
     stop_process(sup)
   end
 


### PR DESCRIPTION
It would be great if i can access to the list of all subscriptions via api.

I've added this functionality for my usecase of showing all active queues.

example usage:
{:ok, subscriptions} = Exq.subscriptions(Exq)
{:ok, ["two", "four", "five"]}

short story:
I have 5 queues named one, two, three, four, five
and i want to highlight active queue which is currently subscribed.
if i am subscribing two, four, five
result would be like this: one, `two`, three, `four`, `five`