### PR TITLE
Have top supervisor wait for worker drainer to gracefully terminate

### DIFF
--- a/lib/exq/support/mode.ex
+++ b/lib/exq/support/mode.ex
@@ -22,13 +22,15 @@ defmodule Exq.Support.Mode do
     children
   end
   def children(:default, opts) do
+    shutdown_timeout = Keyword.get(opts, :shutdown_timeout)
+
     children = [
       worker(Exq.Worker.Metadata, [opts]),
       worker(Exq.Middleware.Server, [opts]),
       worker(Exq.Stats.Server, [opts]),
       supervisor(Exq.Worker.Supervisor, [opts]),
       worker(Exq.Manager.Server, [opts]),
-      worker(Exq.WorkerDrainer.Server, [opts]),
+      worker(Exq.WorkerDrainer.Server, [opts], shutdown: shutdown_timeout),
       worker(Exq.Enqueuer.Server, [opts]),
       worker(Exq.Api.Server, [opts])
     ]

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -362,6 +362,20 @@ defmodule ExqTest do
     assert_received {"short"}
   end
 
+  @tag :slow
+  test "configure worker shutdown time greater than 5000ms" do
+    Process.register(self(), :exqtest)
+    {:ok, sup} = Exq.start_link([shutdown_timeout: 6500])
+    {:ok, _} = Exq.enqueue(Exq, "default", ExqTest.SleepWorker, [7000, :long])
+    {:ok, _} = Exq.enqueue(Exq, "default", ExqTest.SleepWorker, [6000, :short])
+
+    wait()
+    stop_process(sup)
+
+    refute_received {"long"}
+    assert_received {"short"}
+  end
+
   test "handle supervisor tree shutdown properly with stats cleanup" do
     Process.register(self(), :exqtest)
 

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -362,20 +362,6 @@ defmodule ExqTest do
     assert_received {"short"}
   end
 
-  @tag :slow
-  test "configure worker shutdown time greater than 5000ms" do
-    Process.register(self(), :exqtest)
-    {:ok, sup} = Exq.start_link([shutdown_timeout: 6500])
-    {:ok, _} = Exq.enqueue(Exq, "default", ExqTest.SleepWorker, [7000, :long])
-    {:ok, _} = Exq.enqueue(Exq, "default", ExqTest.SleepWorker, [6000, :short])
-
-    wait()
-    stop_process(sup)
-
-    refute_received {"long"}
-    assert_received {"short"}
-  end
-
   test "handle supervisor tree shutdown properly with stats cleanup" do
     Process.register(self(), :exqtest)
 

--- a/test/mode_test.exs
+++ b/test/mode_test.exs
@@ -1,0 +1,14 @@
+defmodule ModeTest do
+  use ExUnit.Case
+
+  test "supervisor waits for worker drainer to terminate" do
+    children = Exq.Support.Mode.children([shutdown_timeout: 10_000])
+
+    worker_drainer_child_spec = find_child(children, Exq.WorkerDrainer.Server)
+    assert {_id, _start, _restart, 10_000, _type, _module} = worker_drainer_child_spec
+  end
+
+  defp find_child(children, child_id) do
+    Enum.find(children, fn({id, _, _, _, _, _}) -> id == child_id end)
+  end
+end


### PR DESCRIPTION
By default, the supervisor waits only 5 seconds.  It should wait for as long as the :shutdown_timeout option is.

Fixes issue #311