### PR TITLE
Fix memory leak with scheduler

### DIFF
--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -125,11 +125,11 @@ defmodule Exq.Redis.JobQueue do
   end
 
   def scheduler_dequeue(redis, namespace) do
-    scheduler_dequeue(redis, namespace, Time.time_to_score)
+    scheduler_dequeue(redis, namespace, Time.time_to_score, Config.get(:scheduler_page_size))
   end
-  def scheduler_dequeue(redis, namespace, max_score) do
+  def scheduler_dequeue(redis, namespace, max_score, page_size) do
     queues = schedule_queues(namespace)
-    commands = Enum.map(queues, &(["ZRANGEBYSCORE", &1, 0, max_score]))
+    commands = Enum.map(queues, &(["ZRANGEBYSCORE", &1, 0, max_score, "LIMIT", 0, page_size]))
     resp = Connection.qp(redis, commands)
     case resp do
       {:error, reason} -> [{:error, reason}]

--- a/lib/exq/support/config.ex
+++ b/lib/exq/support/config.ex
@@ -11,6 +11,7 @@ defmodule Exq.Support.Config do
     scheduler_enable: true,
     concurrency: 100,
     scheduler_poll_timeout: 200,
+    scheduler_page_size: 10,
     poll_timeout: 100,
     redis_timeout: 5000,
     genserver_timeout: 5000,

--- a/test/memory_test.exs
+++ b/test/memory_test.exs
@@ -1,0 +1,49 @@
+defmodule MemoryTest do
+  use ExUnit.Case
+  require Logger
+  import ExqTestUtil
+
+  setup do
+    TestRedis.setup
+    on_exit fn ->
+      TestRedis.teardown
+    end
+    :ok
+  end
+
+  defmodule Worker do
+    def perform(arg) do
+      if arg == "last" do
+        Logger.info("Last message detected")
+        send(:tester, :done)
+      end
+    end
+  end
+
+  @tag timeout: :infinity
+  test "test memory bloat" do
+    starting_memory = :erlang.memory(:total)
+
+    Process.register(self(), :tester)
+
+    {:ok, sup} = Exq.start_link(scheduler_enable: true)
+    for _ <- 1..10_000, do: Exq.enqueue_in(Exq, "default", 5, MemoryTest.Worker, [Enum.reduce(1..10_000, "", fn _, acc -> acc <> "." end)])
+    Exq.enqueue_in(Exq, "default", 5, MemoryTest.Worker, ["last"])
+
+    # Wait for last message
+    receive do
+      :done -> Logger.info("Received done")
+    end
+
+    :timer.sleep(1000)
+
+    memory_used  = :erlang.memory(:total) - starting_memory
+    Logger.debug "Memory used #{memory_used / (1_024 * 1024)} mb"
+    count = Exq.Redis.Connection.zcard!(:testredis, "test:schedule")
+
+    assert count == 0
+    assert memory_used < 10 * (1_024 * 1_024) # 10mb
+    # let stats finish
+    stop_process(sup)
+  end
+end


### PR DESCRIPTION
We payloads that can be up to 400kb in size and when there is a flood of errors that continuously failed we experienced acute memory bloat, seeing some processes grow to 4GB+. 

Investigating the issue it looks like the issue is that the scheduler re-enqueues jobs by fetching *all* schedulable jobs. This fix limits this fetch to a configurable page size.

The ideal solution is to use a LUA script which moves the jobs from the schedule sorted set to the queue atomically and without the round-trip. I plan on implementing this soon and adding it to this pull request.