### PR TITLE
trim dead jobs queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,19 @@ config :exq,
 
 Note that ```scheduler_enable``` has to be set to ```true``` and ```max_retries``` should be greater than ```0```.
 
+### Dead Jobs:
+
+Any job that has failed more than ```max_retries``` times will be
+moved to dead jobs queue. Dead jobs could be manually re-enqueued via
+Sidekiq UI. Max size and timeout of dead jobs queue can be configured via
+these settings:
+
+```elixir
+config :exq,
+  dead_max_jobs: 10_000,
+  dead_timeout_in_seconds: 180 * 24 * 60 * 60, # 6 months
+```
+
 
 ### OTP Application:
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,6 +17,8 @@ config :exq,
   redis_timeout: 5000,
   genserver_timeout: 5000,
   reconnect_on_sleep: 100,
+  dead_max_jobs: 10_000,
+  dead_timeout_in_seconds: 180 * 24 * 60 * 60, # 6 months
   max_retries: 25,
   middleware: [Exq.Middleware.Stats, Exq.Middleware.Job, Exq.Middleware.Manager,
     Exq.Middleware.Logger]

--- a/lib/exq/support/config.ex
+++ b/lib/exq/support/config.ex
@@ -17,6 +17,8 @@ defmodule Exq.Support.Config do
     shutdown_timeout: 5000,
     reconnect_on_sleep: 100,
     max_retries: 25,
+    dead_max_jobs: 10_000,
+    dead_timeout_in_seconds: 180 * 24 * 60 * 60, # 6 months
     stats_flush_interval: 1000,
     stats_batch_size: 2000,
     serializer: Exq.Serializers.JsonSerializer,

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -94,9 +94,9 @@ defmodule WorkerTest do
     use GenServer
 
     # Same reply as Redix connection
-    def handle_call({:commands, [["ZADD"|_]], req_id}, _from, state) do
+    def handle_call({:commands, [["ZADD"|_], ["ZREMRANGEBYSCORE"|_], ["ZREMRANGEBYRANK"|_]], req_id}, _from, state) do
       send :workertest, :zadd_redis
-      {:reply, {req_id, {:ok, [1]}}, state}
+      {:reply, {req_id, {:ok, [1, 0, 0]}}, state}
     end
 
     # Same reply as Redix connection


### PR DESCRIPTION
We had a high redis memory usage problem and after some investigation it turned out that there were more than 500K dead jobs. This PR addresses this problem by trimming based on two configs (size and timeout). Sidkiq provides the same [config](https://github.com/mperham/sidekiq/blob/master/lib/sidekiq.rb#L34-L35) and the [implementation](https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/api.rb#L661-L665) is more or less the same