### PR TITLE
Dequeue & Re-enqueue using LUA script

### DIFF
--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -160,11 +160,15 @@ defmodule Exq.Api.Server do
 
   def handle_call(:clear_scheduled, _from, state) do
     JobQueue.delete_queue(state.redis, state.namespace, "schedule")
+    JobQueue.delete_queue(state.redis, state.namespace, "schedule:job")
+    JobQueue.delete_queue(state.redis, state.namespace, "schedule:queue")
     {:reply, :ok, state}
   end
 
   def handle_call(:clear_retries, _from, state) do
     JobQueue.delete_queue(state.redis, state.namespace, "retry")
+    JobQueue.delete_queue(state.redis, state.namespace, "retry:job")
+    JobQueue.delete_queue(state.redis, state.namespace, "retry:queue")
     {:reply, :ok, state}
   end
 

--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -36,6 +36,15 @@ defmodule Exq.Redis.Connection do
     q(redis, ["DEL", key])
   end
 
+  def hvals!(redis, key) do
+    {:ok, val} = q(redis, ["HVALS", key])
+    val
+  end
+
+  def hdel!(redis, key, val) do
+    q(redis, ["HDEL", key, val])
+  end
+
   def expire!(redis, key, time \\ 10) do
     q(redis, ["EXPIRE", key, time])
   end

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -363,8 +363,10 @@ defmodule Exq.Redis.JobQueue do
     to_job_serialized(queue, worker, args, options, enqueued_at)
   end
   def to_job_serialized(queue, worker, args, options, enqueued_at) do
-    jid = UUID.uuid4
+    jid = Keyword.get_lazy(options, :uniquely, fn() -> UUID.uuid4 end)
     retry = Keyword.get_lazy(options, :max_retries, fn() -> Config.get(:max_retries) end)
+    enqueued_at = Keyword.get_lazy(options, :uniquely_at, fn() -> enqueued_at end)
+
     job = %{queue: queue, retry: retry, class: worker, args: args, jid: jid, enqueued_at: enqueued_at}
     {jid, Config.serializer.encode!(job)}
   end

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -128,7 +128,7 @@ defmodule Exq.Redis.JobQueue do
   end
   def scheduler_dequeue(redis, namespace, max_score) do
     Enum.reduce(schedule_queues(namespace), 0, fn(queue, acc) ->
-      count = Script.eval!(redis, :schedule_dequeue, [queue, full_key(namespace, "queues")], [max_score])
+      count = Script.eval!(redis, :schedule_dequeue, [queue, full_key(namespace, "queues")], [max_score, Config.get(:scheduler_page_size)])
       count + acc
     end)
   end

--- a/lib/exq/redis/script.ex
+++ b/lib/exq/redis/script.ex
@@ -1,0 +1,79 @@
+defmodule Exq.Redis.Script do
+  alias Exq.Redis.Connection
+
+  defmodule Prepare do
+    def script(source) do
+      hash = :crypto.hash(:sha, source)
+                    |> Base.encode16(case: :lower)
+
+      {hash, source}
+    end
+  end
+
+  @scripts %{
+    schedule: Prepare.script("""
+      local schedule_queue_key, job_queue_key = KEYS[1], KEYS[2]
+      local jid, score, job_serialized = ARGV[1], ARGV[2], ARGV[3]
+
+      redis.call('ZADD', schedule_queue_key, score, jid)
+      redis.call('HSET', schedule_queue_key .. ':job', jid, job_serialized)
+      redis.call('HSET', schedule_queue_key .. ':job_queue', jid, job_queue_key)
+      """),
+    schedule_dequeue: Prepare.script("""
+      local schedule_queue_key, queues_key = KEYS[1], KEYS[2]
+      local score = ARGV[1]
+
+      local dequeue_count = 0
+      for i, jid in ipairs(redis.call('ZRANGEBYSCORE', schedule_queue_key, 0, score)) do
+        local job_serialized = redis.call('HGET', schedule_queue_key .. ':job', jid)
+        local job_queue_key = redis.call('HGET', schedule_queue_key .. ':job_queue', jid)
+
+        redis.call('SADD', 'queues', queues_key, job_queue_key)
+        redis.call('LPUSH', job_queue_key, job_serialized)
+
+        redis.call('ZREM', schedule_queue_key, jid)
+        redis.call('HDEL', schedule_queue_key .. ':job', jid)
+        redis.call('HDEL', schedule_queue_key .. ':job_queue', jid)
+
+        dequeue_count = dequeue_count + 1
+      end
+
+      return dequeue_count
+      """),
+    schedule_jobs_with_scores: Prepare.script("""
+      local schedule_queue_key = KEYS[1]
+
+      local jobs_with_scores = {}
+      for i, jid_or_score in ipairs(redis.call('ZRANGEBYSCORE', schedule_queue_key, 0, '+inf', 'WITHSCORES')) do
+        if i % 2 == 0 then
+          redis.call("SET", "score", jid_or_score)
+          table.insert(jobs_with_scores, jid_or_score)
+        else
+          redis.call("SET", "jid", jid_or_score)
+          table.insert(jobs_with_scores, redis.call('HGET', schedule_queue_key .. ':job', jid_or_score))
+        end
+      end
+
+      return jobs_with_scores
+      """)
+  }
+
+  def eval!(redis, script, keys, args) do
+    {hash, source} = @scripts[script]
+
+    {:ok, res} = try do
+      Connection.q(redis, ["EVALSHA", hash, length(keys)] ++ keys ++ args)
+    rescue e in Redix.Error ->
+      stacktrace = System.stacktrace
+
+      case String.split(e.message, " ", parts: 2) do
+        ["NOSCRIPT", _] ->
+          Connection.q(redis, ["EVAL", source, length(keys)] ++ keys ++ args)
+        _ ->
+          reraise e, stacktrace
+      end
+    end
+
+    res
+  end
+end

--- a/lib/exq/redis/script.ex
+++ b/lib/exq/redis/script.ex
@@ -21,10 +21,10 @@ defmodule Exq.Redis.Script do
       """),
     schedule_dequeue: Prepare.script("""
       local schedule_queue_key, queues_key = KEYS[1], KEYS[2]
-      local score = ARGV[1]
+      local score, page_size = ARGV[1], ARGV[2]
 
       local dequeue_count = 0
-      for i, jid in ipairs(redis.call('ZRANGEBYSCORE', schedule_queue_key, 0, score)) do
+      for i, jid in ipairs(redis.call('ZRANGEBYSCORE', schedule_queue_key, 0, score, 'LIMIT', 0, page_size)) do
         local job_serialized = redis.call('HGET', schedule_queue_key .. ':job', jid)
         local job_queue_key = redis.call('HGET', schedule_queue_key .. ':job_queue', jid)
 

--- a/lib/exq/support/config.ex
+++ b/lib/exq/support/config.ex
@@ -11,6 +11,7 @@ defmodule Exq.Support.Config do
     scheduler_enable: true,
     concurrency: 100,
     scheduler_poll_timeout: 200,
+    scheduler_page_size: 10,
     poll_timeout: 100,
     redis_timeout: 5000,
     genserver_timeout: 5000,

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -133,9 +133,8 @@ defmodule ExqTest do
   test "enqueue_at uniquely and run a job" do
     Process.register(self(), :exqtest)
     {:ok, enq_sup} = Exq.start_link(mode: :enqueuer)
-    uniquely_at = Exq.Support.Time.unix_seconds
-    {:ok, _} = Exq.enqueue_at(Exq.Enqueuer, "default", DateTime.utc_now, ExqTest.PerformWorker, [], uniquely: "idempotency_key", uniquely_at: uniquely_at)
-    {:ok, _} = Exq.enqueue_at(Exq.Enqueuer, "default", DateTime.utc_now, ExqTest.PerformWorker, [], uniquely: "idempotency_key", uniquely_at: uniquely_at)
+    {:ok, _} = Exq.enqueue_at(Exq.Enqueuer, "default", DateTime.utc_now, ExqTest.PerformWorker, [], uniquely: "idempotency_key")
+    {:ok, _} = Exq.enqueue_at(Exq.Enqueuer, "default", DateTime.utc_now, ExqTest.PerformWorker, [], uniquely: "idempotency_key")
 
     {:ok, sup} = Exq.start_link(scheduler_enable: true, name: ExqS)
     assert_receive {:worked}

--- a/test/job_queue_test.exs
+++ b/test/job_queue_test.exs
@@ -89,7 +89,7 @@ defmodule JobQueueTest do
   test "scheduler_dequeue enqueue_at" do
     JobQueue.enqueue_at(:testredis, "test", "default", DateTime.utc_now, MyWorker, [], [])
     {jid, job_serialized} = JobQueue.to_job_serialized("retry", MyWorker, [], retry: true)
-    JobQueue.enqueue_job_at(:testredis, "test", job_serialized, jid, DateTime.utc_now, "test:retry")
+    JobQueue.enqueue_job_at(:testredis, "test", job_serialized, jid, "retry", DateTime.utc_now, "test:retry")
     assert JobQueue.scheduler_dequeue(:testredis, "test") == 2
     assert_dequeue_job(["default"], true)
     assert_dequeue_job(["default"], false)

--- a/test/job_queue_test.exs
+++ b/test/job_queue_test.exs
@@ -78,6 +78,19 @@ defmodule JobQueueTest do
     assert_dequeue_job(["default"], false)
   end
 
+  test "scheduler_dequeue paging" do
+    default_page_size = Exq.Support.Config.get(:scheduler_page_size)
+    Mix.Config.persist([exq: [scheduler_page_size: 1]])
+
+    JobQueue.enqueue_in(:testredis, "test", "default", 0, MyWorker, [], [])
+    JobQueue.enqueue_in(:testredis, "test", "default", 0, MyWorker, [], [])
+    assert JobQueue.scheduler_dequeue(:testredis, "test") == 1
+    assert JobQueue.scheduler_dequeue(:testredis, "test") == 1
+    assert JobQueue.scheduler_dequeue(:testredis, "test") == 0
+
+    Mix.Config.persist([exq: [scheduler_page_size: default_page_size]])
+  end
+
   test "scheduler_dequeue multi queue" do
     JobQueue.enqueue_in(:testredis, "test", "default", -1, MyWorker, [], [])
     JobQueue.enqueue_in(:testredis, "test", "myqueue", -1, MyWorker, [], [])


### PR DESCRIPTION
This supports dequeuing and re-enqueuing to the scheduled queues using an atomic LUA script as mentioned in https://github.com/akira/exq/pull/315. 

This also stored JID strings in the scheduled queues and the jobs and associated metadata in Hashes to support overriding the JID to support uniquely scheduling jobs using an idempotency key. 

Note, we've seen that a default page size of 10 is sufficient to clear 1000s of jobs very quickly and the benefit of a smaller page size with this implementation is keeping LUA script execution time small given Redis's single threaded architecture.