### PR TITLE
Update UUID dep in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Exq.Mixfile do
   # { :foobar, "0.1", git: "https://github.com/elixir-lang/foobar.git" }
   defp deps do
     [
-      { :elixir_uuid, ">= 1.2"},
+      { :elixir_uuid, ">= 1.2.0"},
       { :redix, ">= 0.5.0"},
       { :poison, ">= 1.2.0 or ~> 2.0"},
       { :excoveralls, "~> 0.6", only: :test },

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Exq.Mixfile do
   # { :foobar, "0.1", git: "https://github.com/elixir-lang/foobar.git" }
   defp deps do
     [
-      { :uuid, ">= 1.1.0" },
+      { :elixir_uuid, ">= 1.2"},
       { :redix, ">= 0.5.0"},
       { :poison, ">= 1.2.0 or ~> 2.0"},
       { :excoveralls, "~> 0.6", only: :test },


### PR DESCRIPTION
the UUID lib has changed it's name to `elixir_uuid`. The API is exactly the same. Having the old `uuid` and `elixir_uuid` deps is causing dep clash issues in that they both occupy the same namespace. This PR will bring it in line with the newest version and prevent future namespace clashes.

See the note here for more details:
https://github.com/zyro/elixir-uuid#elixir-uuid