### PR TITLE
Fix init func warning

### DIFF
--- a/lib/exq/middleware/server.ex
+++ b/lib/exq/middleware/server.ex
@@ -89,6 +89,10 @@ defmodule Exq.Middleware.Server do
     {:reply, state, state}
   end
 
+  def init(args) do
+    {:ok, args}
+  end
+
 ##===========================================================
 ## Internal Functions
 ##===========================================================


### PR DESCRIPTION
Fix below warning.

```
warning: function init/1 required by behaviour GenServer is not implemented (in module Exq.Middleware.Server).

We will inject a default implementation for now:

    def init(args) do
      {:ok, args}
    end

You can copy the implementation above or define your own that converts the arguments given to GenServer.start_link/3 to the server state.

  lib/exq/middleware/server.ex:1
```