### PR TITLE
Support load from runtime env for more config params

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -16,6 +16,7 @@ config :exq,
   poll_timeout: 100,
   redis_timeout: 5000,
   genserver_timeout: 5000,
+  shutdown_timeout: 5000,
   reconnect_on_sleep: 100,
   dead_max_jobs: 10_000,
   dead_timeout_in_seconds: 180 * 24 * 60 * 60, # 6 months

--- a/lib/exq/support/coercion.ex
+++ b/lib/exq/support/coercion.ex
@@ -22,4 +22,21 @@ defmodule Exq.Support.Coercion do
     raise ArgumentError,
       message: "Failed to parse #{inspect(value)} into an integer."
   end
+
+  def to_boolean(value) when is_boolean(value) do
+    value
+  end
+
+  @true_values ["true", "yes", "1"]
+  def to_boolean(value) when is_binary(value) do
+    case value |> String.trim() |> String.downcase() do
+      x when x in @true_values -> true
+      _ -> false
+    end
+  end
+
+  def to_boolean(value) do
+    raise ArgumentError,
+      message: "Failed to parse #{inspect(value)} into a boolean."
+  end
 end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -206,7 +206,7 @@ defmodule Exq.ConfigTest do
 
   test "custom redis module" do
     with_application_env(:exq, :redis_worker, {RedisWorker, [1, 2]}, fn ->
-      {module, args, server_opts} = Exq.Support.Opts.redis_worker_opts([mode: :default])
+      {module, args, _server_opts} = Exq.Support.Opts.redis_worker_opts([mode: :default])
       assert module == RedisWorker
       assert args == [1, 2]
     end)


### PR DESCRIPTION
First of all, thank you for the great library.

When using it I was surprised that some of the config parameters could use the syntax  `{:system, VAR}` and some others could not.

This MR adds `{:system, VAR}` format support for integer parameters that are not supporting it yet and to boolean parameters.

In addition to integers, I supported `:infinity` for the `:concurrency` parameter. I assumed that no other parameter could be `:infinity` as there are no such tests or documentation.

I can add support for list of string in this or another MR (for `:queues`) if wanted.
A proposition of format could be splitting on comas, i.e. `"a,b,c"` parsed as `["a", "b", "c"]`.

Any suggestion is welcome.