### PR TITLE
Specify less than 0.8.0 on redix version in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule Exq.Mixfile do
   defp deps do
     [
       { :elixir_uuid, ">= 1.2.0"},
-      { :redix, ">= 0.5.0"},
+      { :redix, ">= 0.5.0 and < 0.8.0"},
       { :poison, ">= 1.2.0 or ~> 2.0"},
       { :excoveralls, "~> 0.6", only: :test },
       { :redix_sentinel, "~> 0.5.0", only: :test },


### PR DESCRIPTION
There were some breaking changes introduced in redix 0.8.0

Closes #336
Closes #337

(btw, does `mix deps.get` not look at the mix.lock of the dependency to get the sub-dependencies?  I would have expected that but mine got redix 0.8.1 so it failed ¯\_(ツ)_/¯)