### PR TITLE
Allow setting mode to both [:enqueuer, :api]

### DIFF
--- a/lib/exq/support/mode.ex
+++ b/lib/exq/support/mode.ex
@@ -47,4 +47,11 @@ defmodule Exq.Support.Mode do
   def children(:api, opts) do
     [worker(Exq.Api.Server, [opts])]
   end
+  def children([:enqueuer, :api], opts) do
+    [
+      worker(Exq.Enqueuer.Server, [opts]),
+      worker(Exq.Api.Server, [opts])
+    ]
+  end
+  def children([:api, :enqueuer], opts), do: children([:enqueuer, :api], opts)
 end

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -140,6 +140,17 @@ defmodule ExqTest do
     stop_process(enq_sup)
   end
 
+  test "enqueue with separate enqueuer and api" do
+    Process.register(self(), :exqtest)
+    {:ok, exq_sup} = Exq.start_link
+    {:ok, enq_sup} = Exq.start_link(mode: [:enqueuer, :api], name: ExqE)
+    {:ok, _} = Exq.Enqueuer.enqueue(ExqE.Enqueuer, "default", ExqTest.PerformWorker, [])
+    {:ok, _} = Exq.Api.queues(ExqE.Api)
+    assert_receive {:worked}
+    stop_process(exq_sup)
+    stop_process(enq_sup)
+  end
+
   test "enqueue with separate enqueuer even if main Exq process is down" do
     Process.register(self(), :exqtest)
     {:ok, exq_sup} = Exq.start_link


### PR DESCRIPTION
For our use case, it's less that we want the enqueuer to be independent, but rather we want the processor to be independent, and the other node to be everything else (and I'm assuming this isn't super uncommon, basically being able to add to and delete from the queue from one node, and the other node just processing the queue).  This solution seemed to be the most straight forward way to accomplish that.

Close #341 
