### PR TITLE
Add default for json_library value

### DIFF
--- a/lib/exq/serializers/json_serializer.ex
+++ b/lib/exq/serializers/json_serializer.ex
@@ -1,8 +1,9 @@
 defmodule Exq.Serializers.JsonSerializer do
   @behaviour Exq.Serializers.Behaviour
+  alias Exq.Support.Config
 
   defp json_library do
-    Application.fetch_env!(:exq, :json_library)
+    Config.get(:json_library)
   end
 
   def decode(json) do

--- a/lib/exq/support/config.ex
+++ b/lib/exq/support/config.ex
@@ -8,6 +8,7 @@ defmodule Exq.Support.Config do
     redis_options: [],
     namespace: "exq",
     queues: ["default"],
+    json_library: Jason,
     scheduler_enable: true,
     concurrency: 100,
     scheduler_poll_timeout: 200,


### PR DESCRIPTION
Added to ensure that previous versions will still work without needing
to add the json_library property.

Fixes #369 