### PR TITLE
start all the apps during test.

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -19,6 +19,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], []},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
   "ranch": {:hex, :ranch, "1.7.0", "9583f47160ca62af7f8d5db11454068eaa32b56eeadf984d4f46e61a076df5f2", [:rebar3], []},
-  "redix": {:hex, :redix, "0.9.0", "c631c921354587e054bf1e2a6b7d0120d617352fc42b624b9ca79ea484d0326c", [:mix], [], "hexpm"},
+  "redix": {:hex, :redix, "0.10.2", "a9eabf47898aa878650df36194aeb63966d74f5bd69d9caa37babb32dbb93c5d", [:mix], [{:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
 }

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -160,7 +160,9 @@ end
 ExUnit.configure(seed: 0, max_cases: 1, exclude: [failure_scenarios: true, pending: true])
 
 # Start logger
-:application.start(:logger)
+for app <- [:logger, :redix, :elixir_uuid] do
+  Application.ensure_all_started(app)
+end
 
 TestRedis.start()
 


### PR DESCRIPTION
This will prevent the test from being broken when a new transitive
dependency got added.