### PR TITLE
Add support for explicitly retrying jobs

### DIFF
--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -65,6 +65,12 @@ defmodule WorkerTest do
     end
   end
 
+  defmodule RetryWorker do
+    def perform do
+      {:retry, "Retry message"}
+    end
+  end
+
   defmodule MockStatsServer do
     use GenServer
 
@@ -218,6 +224,11 @@ defmodule WorkerTest do
 
   test "worker killed still sends stats" do
     {:ok, worker} = start_worker({"WorkerTest.SuicideWorker", "[]"})
+    assert_terminate(worker, false)
+  end
+
+  test "worker that sends a retry tuple will retry" do
+    {:ok, worker} = start_worker({"WorkerTest.RetryWorker", "[]"})
     assert_terminate(worker, false)
   end
 


### PR DESCRIPTION
We are using Exq with jobs that fail often because of factors out of our control.
Sometimes a job needs to be retried 30 times over a long period. However, all failed jobs produce a log statement of a crashed process. These logs are undesirable because the failure is expected, and it pollutes the logfiles.
This patch contains a proposal to allow jobs to flag themselves as failed by returning a tuple of a certain shape. Let me know what you think. I am also open to other options that produce the same result :) 