### PR TITLE
cast queue level concurrency

### DIFF
--- a/lib/exq/support/opts.ex
+++ b/lib/exq/support/opts.ex
@@ -124,27 +124,27 @@ defmodule Exq.Support.Opts do
   end
 
   defp get_config_concurrency() do
-    case Config.get(:concurrency) do
-      x when is_atom(x) ->
-        x
-
-      x when is_integer(x) ->
-        x
-
-      x when is_binary(x) ->
-        case x |> String.trim() |> String.downcase() do
-          "infinity" -> :infinity
-          x -> Coercion.to_integer(x)
-        end
-    end
+    cast_concurrency(Config.get(:concurrency))
   end
 
   defp get_concurrency(queue_configs, per_queue_concurrency) do
     Enum.map(queue_configs, fn queue_config ->
       case queue_config do
-        {queue, concurrency} -> {queue, concurrency, 0}
+        {queue, concurrency} -> {queue, cast_concurrency(concurrency), 0}
         queue -> {queue, per_queue_concurrency, 0}
       end
     end)
+  end
+
+  defp cast_concurrency(:infinity), do: :infinity
+  defp cast_concurrency(:infinite), do: :infinity
+  defp cast_concurrency(x) when is_integer(x), do: x
+
+  defp cast_concurrency(x) when is_binary(x) do
+    case x |> String.trim() |> String.downcase() do
+      "infinity" -> :infinity
+      "infinite" -> :infinity
+      x -> Coercion.to_integer(x)
+    end
   end
 end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -181,6 +181,18 @@ defmodule Exq.ConfigTest do
 
     assert server_opts[:queues] == ["default", "test1"]
     assert server_opts[:concurrency] == [{"default", 1000, 0}, {"test1", 2000, 0}]
+
+    Mix.Config.persist(
+      exq: [queues: [{"default", "1000"}, {"test1", "infinite"}, {"test2", "infinity"}]]
+    )
+
+    {Redix, [_redis_opts], server_opts} = Exq.Support.Opts.redis_worker_opts(mode: :default)
+
+    assert server_opts[:concurrency] == [
+             {"default", 1000, 0},
+             {"test1", :infinity, 0},
+             {"test2", :infinity, 0}
+           ]
   end
 
   test "api redis_worker_opts" do


### PR DESCRIPTION
We currently cast the global concurrency config. Make the logic uniform by casting queue level concurrency config as well. fixes #386 