### PR TITLE
exq.run mix task should start dependent apps as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- exq.run mix task starts dependent apps as well
+
 
 ## [0.13.5] - 2020-01-01
 

--- a/lib/mix/tasks/exq.run.ex
+++ b/lib/mix/tasks/exq.run.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Exq.Run do
   @shortdoc "Starts the Exq worker"
 
   def run(_args) do
-    Exq.start_link()
+    {:ok, _} = Application.ensure_all_started(:exq)
     IO.puts("Started Exq")
     :timer.sleep(:infinity)
   end


### PR DESCRIPTION
Otherwise we get warnings like below

15:48:47.253 [warn]  Failed to lookup telemetry handlers. Ensure the telemetry application has been started.

15:48:47.357 [warn]  Failed to lookup telemetry handlers. Ensure the telemetry application has been started.