### PR TITLE
Conflicting units in the doc for enqueue_in

### DIFF
--- a/lib/exq/enqueue_api.ex
+++ b/lib/exq/enqueue_api.ex
@@ -54,7 +54,7 @@ defmodule Exq.Enqueuer.EnqueueApi do
       end
 
       @doc """
-      Schedule a job to be enqueued at in the future given by offset in milliseconds.
+      Schedule a job to be enqueued at in the future given by offset in seconds.
 
       Expected args:
         * `pid` - PID for Exq Manager or Enqueuer to handle this


### PR DESCRIPTION
The initial comment says the offset is in milliseconds, the doc for the offset says (correctly) it is in seconds. This just corrects the first.