### PR TITLE
Add ability to control the dequeue

### DIFF
--- a/lib/exq/dequeue/behaviour.ex
+++ b/lib/exq/dequeue/behaviour.ex
@@ -1,6 +1,6 @@
 defmodule Exq.Dequeue.Behaviour do
   @callback init(info :: map, args :: term) :: {:ok, term}
-  @callback stop(state :: term) :: {:ok, term}
+  @callback stop(state :: term) :: :ok
   @callback available?(state :: term) :: {:ok, boolean, term}
   @callback dispatched(state :: term) :: {:ok, term}
   @callback processed(state :: term) :: {:ok, term}

--- a/lib/exq/dequeue/behaviour.ex
+++ b/lib/exq/dequeue/behaviour.ex
@@ -1,5 +1,38 @@
 defmodule Exq.Dequeue.Behaviour do
-  @callback init(info :: map, args :: term) :: {:ok, term}
+  @moduledoc """
+  Custom concurreny or rate limiting at a queue level can be achieved
+  by implementing the Dequeue behaviour
+
+  The following config can be used to customize dequeue behaviour for a queue
+
+      config :exq,
+        queues: [{"default", {RateLimiter, options}}]
+
+  RateLimiter module should implement `Exq.Dequeue.Behaviour`. The
+  options supplied here would be passed as the second argument to the
+  `c:init/2` function.
+
+  ### Life cycle
+
+  `c:init/2` will be invoked on initialization. The first argument will contain info
+  like queue and the second argument is user configurable.
+
+  `c:available?/1` will be invoked before each poll. If the
+  returned value contains `false` as the second element of the tuple,
+  the queue will not polled
+
+  `c:dispatched/1` will be invoked once a job is dispatched to the worker
+
+  `c:processed/1` will be invoked if a job completed successfully
+
+  `c:failed/1` will be invoked if a job failed
+
+  `c:stop/1` will be invoked when a queue is unsubscribed or before the
+  node terminates. Note: there is no guarantee this will be invoked if
+  the node terminates abruptly
+  """
+
+  @callback init(info :: %{queue: String.t()}, args :: term) :: {:ok, term}
   @callback stop(state :: term) :: :ok
   @callback available?(state :: term) :: {:ok, boolean, term}
   @callback dispatched(state :: term) :: {:ok, term}

--- a/lib/exq/dequeue/behaviour.ex
+++ b/lib/exq/dequeue/behaviour.ex
@@ -1,0 +1,8 @@
+defmodule Exq.Dequeue.Behaviour do
+  @callback init(info :: map, args :: term) :: {:ok, term}
+  @callback stop(state :: term) :: {:ok, term}
+  @callback available?(state :: term) :: {:ok, boolean, term}
+  @callback dispatched(state :: term) :: {:ok, term}
+  @callback processed(state :: term) :: {:ok, term}
+  @callback failed(state :: term) :: {:ok, term}
+end

--- a/lib/exq/dequeue/local.ex
+++ b/lib/exq/dequeue/local.ex
@@ -1,0 +1,21 @@
+defmodule Exq.Dequeue.Local do
+  @behaviour Exq.Dequeue.Behaviour
+
+  defmodule State do
+    defstruct max: nil, current: 0
+  end
+
+  def init(%{queue: queue}, %{concurrency: concurrency}) do
+    {:ok, %State{max: concurrency}}
+  end
+
+  def stop(_), do: {:ok, nil}
+
+  def available?(state), do: {:ok, state.current < state.max, state}
+
+  def dispatched(state), do: {:ok, %{state | current: state.current + 1}}
+
+  def processed(state), do: {:ok, %{state | current: state.current - 1}}
+
+  def failed(state), do: {:ok, %{state | current: state.current - 1}}
+end

--- a/lib/exq/dequeue/local.ex
+++ b/lib/exq/dequeue/local.ex
@@ -6,8 +6,8 @@ defmodule Exq.Dequeue.Local do
   end
 
   @impl true
-  def init(%{queue: queue}, %{concurrency: concurrency}) do
-    {:ok, %State{max: concurrency}}
+  def init(%{queue: queue}, options) do
+    {:ok, %State{max: Keyword.fetch!(options, :concurrency)}}
   end
 
   @impl true

--- a/lib/exq/dequeue/local.ex
+++ b/lib/exq/dequeue/local.ex
@@ -2,6 +2,8 @@ defmodule Exq.Dequeue.Local do
   @behaviour Exq.Dequeue.Behaviour
 
   defmodule State do
+    @moduledoc false
+
     defstruct max: nil, current: 0
   end
 

--- a/lib/exq/dequeue/local.ex
+++ b/lib/exq/dequeue/local.ex
@@ -6,7 +6,7 @@ defmodule Exq.Dequeue.Local do
   end
 
   @impl true
-  def init(%{queue: queue}, options) do
+  def init(_, options) do
     {:ok, %State{max: Keyword.fetch!(options, :concurrency)}}
   end
 

--- a/lib/exq/dequeue/local.ex
+++ b/lib/exq/dequeue/local.ex
@@ -5,17 +5,23 @@ defmodule Exq.Dequeue.Local do
     defstruct max: nil, current: 0
   end
 
+  @impl true
   def init(%{queue: queue}, %{concurrency: concurrency}) do
     {:ok, %State{max: concurrency}}
   end
 
-  def stop(_), do: {:ok, nil}
+  @impl true
+  def stop(_), do: :ok
 
+  @impl true
   def available?(state), do: {:ok, state.current < state.max, state}
 
+  @impl true
   def dispatched(state), do: {:ok, %{state | current: state.current + 1}}
 
+  @impl true
   def processed(state), do: {:ok, %{state | current: state.current - 1}}
 
+  @impl true
   def failed(state), do: {:ok, %{state | current: state.current - 1}}
 end

--- a/lib/exq/manager/server.ex
+++ b/lib/exq/manager/server.ex
@@ -369,8 +369,10 @@ defmodule Exq.Manager.Server do
   defp maybe_call_dequeuer(dequeuers, queue, method) do
     if Map.has_key?(dequeuers, queue) do
       Map.update!(dequeuers, queue, fn {module, state} ->
-        {:ok, state} = apply(module, method, [state])
-        {module, state}
+        case apply(module, method, [state]) do
+          {:ok, state} -> {module, state}
+          :ok -> {module, nil}
+        end
       end)
     else
       dequeuers

--- a/lib/exq/manager/server.ex
+++ b/lib/exq/manager/server.ex
@@ -304,7 +304,6 @@ defmodule Exq.Manager.Server do
           job,
           state.pid,
           queue,
-          state.work_table,
           state.stats,
           state.namespace,
           state.node_id,

--- a/lib/exq/middleware/manager.ex
+++ b/lib/exq/middleware/manager.ex
@@ -9,19 +9,18 @@ defmodule Exq.Middleware.Manager do
   end
 
   def after_processed_work(pipeline) do
-    pipeline |> notify
+    pipeline |> notify(true)
   end
 
   def after_failed_work(pipeline) do
-    pipeline |> notify
+    pipeline |> notify(false)
   end
 
-  defp notify(%Pipeline{assigns: assigns} = pipeline) do
+  defp notify(%Pipeline{assigns: assigns} = pipeline, success) do
     Manager.job_terminated(
       assigns.manager,
-      assigns.namespace,
       assigns.queue,
-      assigns.job_serialized
+      success
     )
 
     pipeline

--- a/lib/exq/support/opts.ex
+++ b/lib/exq/support/opts.ex
@@ -147,15 +147,15 @@ defmodule Exq.Support.Opts do
   end
 
   def cast_concurrency({module, options}), do: {module, options}
-  def cast_concurrency(:infinity), do: {Exq.Dequeue.Local, %{concurrency: :infinity}}
-  def cast_concurrency(:infinite), do: {Exq.Dequeue.Local, %{concurrency: :infinity}}
-  def cast_concurrency(x) when is_integer(x), do: {Exq.Dequeue.Local, %{concurrency: x}}
+  def cast_concurrency(:infinity), do: {Exq.Dequeue.Local, [concurrency: :infinity]}
+  def cast_concurrency(:infinite), do: {Exq.Dequeue.Local, [concurrency: :infinity]}
+  def cast_concurrency(x) when is_integer(x), do: {Exq.Dequeue.Local, [concurrency: x]}
 
   def cast_concurrency(x) when is_binary(x) do
     case x |> String.trim() |> String.downcase() do
-      "infinity" -> {Exq.Dequeue.Local, %{concurrency: :infinity}}
-      "infinite" -> {Exq.Dequeue.Local, %{concurrency: :infinity}}
-      x -> {Exq.Dequeue.Local, %{concurrency: Coercion.to_integer(x)}}
+      "infinity" -> {Exq.Dequeue.Local, [concurrency: :infinity]}
+      "infinite" -> {Exq.Dequeue.Local, [concurrency: :infinity]}
+      x -> {Exq.Dequeue.Local, [concurrency: Coercion.to_integer(x)]}
     end
   end
 end

--- a/lib/exq/worker/server.ex
+++ b/lib/exq/worker/server.ex
@@ -9,7 +9,6 @@ defmodule Exq.Worker.Server do
     * `job_serialized` - Full JSON payload of the Job.
     * `manager` - Manager process pid.
     * `queue` - The queue the job came from.
-    * `:work_table` - In process work ets table (TODO: Remove).
     * `stats` - Stats process pid.
     * `namespace` - Redis namespace
     * `host` - Host name
@@ -27,7 +26,6 @@ defmodule Exq.Worker.Server do
               manager: nil,
               queue: nil,
               namespace: nil,
-              work_table: nil,
               stats: nil,
               host: nil,
               redis: nil,
@@ -41,7 +39,6 @@ defmodule Exq.Worker.Server do
         job_serialized,
         manager,
         queue,
-        work_table,
         stats,
         namespace,
         host,
@@ -51,8 +48,7 @@ defmodule Exq.Worker.Server do
       ) do
     GenServer.start_link(
       __MODULE__,
-      {job_serialized, manager, queue, work_table, stats, namespace, host, redis, middleware,
-       metadata},
+      {job_serialized, manager, queue, stats, namespace, host, redis, middleware, metadata},
       []
     )
   end
@@ -68,17 +64,13 @@ defmodule Exq.Worker.Server do
   ## gen server callbacks
   ## ===========================================================
 
-  def init(
-        {job_serialized, manager, queue, work_table, stats, namespace, host, redis, middleware,
-         metadata}
-      ) do
+  def init({job_serialized, manager, queue, stats, namespace, host, redis, middleware, metadata}) do
     {
       :ok,
       %State{
         job_serialized: job_serialized,
         manager: manager,
         queue: queue,
-        work_table: work_table,
         stats: stats,
         namespace: namespace,
         host: host,

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -167,7 +167,7 @@ defmodule Exq.ConfigTest do
     assert metadata == Exq.Worker.Metadata
     assert queues == ["default"]
     assert redis == Exq.Redis.Client
-    assert concurrency == [{"default", {Exq.Dequeue.Local, %{concurrency: 100}}}]
+    assert concurrency == [{"default", {Exq.Dequeue.Local, [concurrency: 100]}}]
     assert middleware == Exq.Middleware.Server
 
     assert default_middleware == [
@@ -185,8 +185,8 @@ defmodule Exq.ConfigTest do
     assert server_opts[:queues] == ["default", "test1"]
 
     assert server_opts[:concurrency] == [
-             {"default", {Exq.Dequeue.Local, %{concurrency: 1000}}},
-             {"test1", {Exq.Dequeue.Local, %{concurrency: 2000}}}
+             {"default", {Exq.Dequeue.Local, [concurrency: 1000]}},
+             {"test1", {Exq.Dequeue.Local, [concurrency: 2000]}}
            ]
 
     Mix.Config.persist(
@@ -202,10 +202,10 @@ defmodule Exq.ConfigTest do
     {Redix, [_redis_opts], server_opts} = Exq.Support.Opts.redis_worker_opts(mode: :default)
 
     assert server_opts[:concurrency] == [
-             {"default", {Exq.Dequeue.Local, %{concurrency: 1000}}},
+             {"default", {Exq.Dequeue.Local, [concurrency: 1000]}},
              {
                "test1",
-               {Exq.Dequeue.Local, %{concurrency: :infinity}}
+               {Exq.Dequeue.Local, [concurrency: :infinity]}
              },
              {
                "test2",
@@ -248,7 +248,7 @@ defmodule Exq.ConfigTest do
     {Redix, [_redis_opts], server_opts} = Exq.Support.Opts.redis_worker_opts(mode: :default)
 
     assert server_opts[:namespace] == "test"
-    assert server_opts[:concurrency] == [{"default", {Exq.Dequeue.Local, %{concurrency: 333}}}]
+    assert server_opts[:concurrency] == [{"default", {Exq.Dequeue.Local, [concurrency: 333]}}]
     assert server_opts[:poll_timeout] == 17
     assert server_opts[:scheduler_poll_timeout] == 123
     assert server_opts[:scheduler_enable] == true
@@ -267,7 +267,7 @@ defmodule Exq.ConfigTest do
     {Redix, [_redis_opts], server_opts} = Exq.Support.Opts.redis_worker_opts(mode: :default)
 
     assert server_opts[:concurrency] == [
-             {"default", {Exq.Dequeue.Local, %{concurrency: :infinity}}}
+             {"default", {Exq.Dequeue.Local, [concurrency: :infinity]}}
            ]
   end
 end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -167,7 +167,7 @@ defmodule Exq.ConfigTest do
     assert metadata == Exq.Worker.Metadata
     assert queues == ["default"]
     assert redis == Exq.Redis.Client
-    assert concurrency == [{"default", 100, 0}]
+    assert concurrency == [{"default", {Exq.Dequeue.Local, %{concurrency: 100}}}]
     assert middleware == Exq.Middleware.Server
 
     assert default_middleware == [
@@ -183,18 +183,34 @@ defmodule Exq.ConfigTest do
     {Redix, [_redis_opts], server_opts} = Exq.Support.Opts.redis_worker_opts(mode: :default)
 
     assert server_opts[:queues] == ["default", "test1"]
-    assert server_opts[:concurrency] == [{"default", 1000, 0}, {"test1", 2000, 0}]
+
+    assert server_opts[:concurrency] == [
+             {"default", {Exq.Dequeue.Local, %{concurrency: 1000}}},
+             {"test1", {Exq.Dequeue.Local, %{concurrency: 2000}}}
+           ]
 
     Mix.Config.persist(
-      exq: [queues: [{"default", "1000"}, {"test1", "infinite"}, {"test2", "infinity"}]]
+      exq: [
+        queues: [
+          {"default", "1000"},
+          {"test1", "infinite"},
+          {"test2", {External.BucketLimiter, %{size: 60, limit: 5}}}
+        ]
+      ]
     )
 
     {Redix, [_redis_opts], server_opts} = Exq.Support.Opts.redis_worker_opts(mode: :default)
 
     assert server_opts[:concurrency] == [
-             {"default", 1000, 0},
-             {"test1", :infinity, 0},
-             {"test2", :infinity, 0}
+             {"default", {Exq.Dequeue.Local, %{concurrency: 1000}}},
+             {
+               "test1",
+               {Exq.Dequeue.Local, %{concurrency: :infinity}}
+             },
+             {
+               "test2",
+               {External.BucketLimiter, %{size: 60, limit: 5}}
+             }
            ]
   end
 
@@ -232,7 +248,7 @@ defmodule Exq.ConfigTest do
     {Redix, [_redis_opts], server_opts} = Exq.Support.Opts.redis_worker_opts(mode: :default)
 
     assert server_opts[:namespace] == "test"
-    assert server_opts[:concurrency] == [{"default", 333, 0}]
+    assert server_opts[:concurrency] == [{"default", {Exq.Dequeue.Local, %{concurrency: 333}}}]
     assert server_opts[:poll_timeout] == 17
     assert server_opts[:scheduler_poll_timeout] == 123
     assert server_opts[:scheduler_enable] == true
@@ -250,6 +266,8 @@ defmodule Exq.ConfigTest do
 
     {Redix, [_redis_opts], server_opts} = Exq.Support.Opts.redis_worker_opts(mode: :default)
 
-    assert server_opts[:concurrency] == [{"default", :infinity, 0}]
+    assert server_opts[:concurrency] == [
+             {"default", {Exq.Dequeue.Local, %{concurrency: :infinity}}}
+           ]
   end
 end

--- a/test/middleware_test.exs
+++ b/test/middleware_test.exs
@@ -127,7 +127,6 @@ defmodule MiddlewareTest do
     job =
       "{ \"queue\": \"default\", \"class\": \"#{class}\", \"args\": #{args}, \"jid\": \"123\" }"
 
-    work_table = :ets.new(:work_table, [:set, :public])
     {:ok, stub_server} = GenServer.start_link(MiddlewareTest.StubServer, [])
 
     {:ok, metadata} = Exq.Worker.Metadata.start_link(%{})
@@ -136,7 +135,6 @@ defmodule MiddlewareTest do
       job,
       stub_server,
       "default",
-      work_table,
       stub_server,
       "exq",
       "localhost",

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -130,7 +130,7 @@ defmodule WorkerTest do
       {:keep_state, data}
     end
 
-    def connected(:cast, {:job_terminated, _, _, _}, data) do
+    def connected(:cast, {:job_terminated, _queue, _success}, data) do
       send(:workertest, :job_terminated)
       {:keep_state, data}
     end

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -159,7 +159,6 @@ defmodule WorkerTest do
     Process.register(self(), :workertest)
     job = "{ \"queue\": \"default\", \"class\": \"#{class}\", \"args\": #{args} }"
 
-    work_table = :ets.new(:work_table, [:set, :public])
     {:ok, stub_server} = WorkerTest.MockServer.start_link()
     {:ok, mock_stats_server} = GenServer.start_link(WorkerTest.MockStatsServer, %{})
     {:ok, middleware} = GenServer.start_link(Exq.Middleware.Server, [])
@@ -173,7 +172,6 @@ defmodule WorkerTest do
       job,
       stub_server,
       "default",
-      work_table,
       mock_stats_server,
       "exq",
       "localhost",


### PR DESCRIPTION
### Problem

Currently, Exq provides concurrency control per queue per worker node. But if anyone wants to rate limit based on different factors, it's not possible to do unless via middleware. The problem with going via middleware is, the job is already dequeued at that point and the only way to stop further dequeue is via `unsubscribe` API. The unsubscribe API is async, so we can't control the exact number of jobs dequeued via it.

### Proposal

Add the ability to control dequeue operation via a new Behaviour. Exq will provide a default implementation and others can override the default implementation per queue.

### POC

I have been working on a POC [exq_limit](https://github.com/ananthakumaran/exq_limit) to validate the API. I will try to test it in the coming weeks.

refer #178 