### PR TITLE
re-enqueue unfinished jobs to the begining of queue on restart

### DIFF
--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -103,10 +103,6 @@ defmodule Exq.Redis.Connection do
     q(redis, ["LPOP", key])
   end
 
-  def rpoplpush(redis, key, backup) do
-    q(redis, ["RPOPLPUSH", key, backup])
-  end
-
   def zadd(redis, set, score, member) do
     q(redis, ["ZADD", set, score, member])
   end
@@ -184,7 +180,7 @@ defmodule Exq.Redis.Connection do
   defp handle_response({:error, %{message: "NOSCRIPT" <> _rest}} = error, _) do
     error
   end
-  
+
   defp handle_response({:error, %Redix.ConnectionError{reason: :disconnected}} = error, _) do
     error
   end

--- a/lib/exq/redis/script.ex
+++ b/lib/exq/redis/script.ex
@@ -12,6 +12,22 @@ defmodule Exq.Redis.Script do
   end
 
   @scripts %{
+    mlpop_rpush:
+      Prepare.script("""
+      local from, to = KEYS[1], KEYS[2]
+      local limit = tonumber(ARGV[1])
+      local length = redis.call('LLEN', from)
+      local value = nil
+      local moved = 0
+      while limit > 0 and length > 0 do
+        value = redis.call('LPOP', from)
+        redis.call('RPUSH', to, value)
+        limit = limit - 1
+        length = length - 1
+        moved = moved + 1
+      end
+      return {length, moved}
+      """),
     heartbeat_re_enqueue_backup:
       Prepare.script("""
       local function contains(table, element)
@@ -24,12 +40,22 @@ defmodule Exq.Redis.Script do
       end
 
       local backup_queue_key, queue_key, heartbeat_key = KEYS[1], KEYS[2], KEYS[3]
-      local node_id, expected_score = ARGV[1], ARGV[2]
+      local node_id, expected_score, limit = ARGV[1], ARGV[2], tonumber(ARGV[3])
       local node_ids = redis.call('ZRANGEBYSCORE', heartbeat_key, expected_score, expected_score)
       if contains(node_ids, node_id) then
-        return redis.call('RPOPLPUSH', backup_queue_key, queue_key)
+        local length = redis.call('LLEN', backup_queue_key)
+        local value = nil
+        local moved = 0
+        while limit > 0 and length > 0 do
+          value = redis.call('LPOP', backup_queue_key)
+          redis.call('RPUSH', queue_key, value)
+          limit = limit - 1
+          length = length - 1
+          moved = moved + 1
+        end
+        return {length, moved}
       else
-        return nil
+        return {0, 0}
       end
       """)
   }

--- a/test/job_queue_test.exs
+++ b/test/job_queue_test.exs
@@ -20,10 +20,17 @@ defmodule JobQueueTest do
     jobs = JobQueue.dequeue(:testredis, "test", @host, queues)
     result = jobs |> Enum.reject(fn {:ok, {status, _}} -> status == :none end)
 
-    if is_boolean(expected_result) do
-      assert expected_result == !Enum.empty?(result)
-    else
-      assert expected_result == Enum.count(result)
+    cond do
+      is_boolean(expected_result) ->
+        assert expected_result == !Enum.empty?(result)
+
+      is_integer(expected_result) ->
+        assert expected_result == Enum.count(result)
+
+      is_map(expected_result) ->
+        [{:ok, {job_string, _queue}}] = result
+        job = Jason.decode!(job_string)
+        assert expected_result == Map.take(job, Map.keys(expected_result))
     end
   end
 
@@ -43,14 +50,37 @@ defmodule JobQueueTest do
   end
 
   test "backup queue" do
-    JobQueue.enqueue(:testredis, "test", "default", MyWorker, [], [])
-    JobQueue.enqueue(:testredis, "test", "default", MyWorker, [], [])
-    assert_dequeue_job(["default"], true)
-    assert_dequeue_job(["default"], true)
+    JobQueue.enqueue(:testredis, "test", "default", MyWorker, [1], [])
+    JobQueue.enqueue(:testredis, "test", "default", MyWorker, [2], [])
+    assert_dequeue_job(["default"], %{"args" => [1]})
+    assert_dequeue_job(["default"], %{"args" => [2]})
     assert_dequeue_job(["default"], false)
+    JobQueue.enqueue(:testredis, "test", "default", MyWorker, [3], [])
+    JobQueue.enqueue(:testredis, "test", "default", MyWorker, [4], [])
     JobQueue.re_enqueue_backup(:testredis, "test", @host, "default")
-    assert_dequeue_job(["default"], true)
-    assert_dequeue_job(["default"], true)
+    assert_dequeue_job(["default"], %{"args" => [1]})
+    assert_dequeue_job(["default"], %{"args" => [2]})
+    assert_dequeue_job(["default"], %{"args" => [3]})
+    assert_dequeue_job(["default"], %{"args" => [4]})
+    assert_dequeue_job(["default"], false)
+  end
+
+  test "backup queue re enqueues all jobs" do
+    for i <- 1..15 do
+      JobQueue.enqueue(:testredis, "test", "default", MyWorker, [i], [])
+      assert_dequeue_job(["default"], %{"args" => [i]})
+    end
+
+    for i <- 16..30 do
+      JobQueue.enqueue(:testredis, "test", "default", MyWorker, [i], [])
+    end
+
+    JobQueue.re_enqueue_backup(:testredis, "test", @host, "default")
+
+    for i <- 1..30 do
+      assert_dequeue_job(["default"], %{"args" => [i]})
+    end
+
     assert_dequeue_job(["default"], false)
   end
 

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -160,27 +160,53 @@ defmodule WorkerTest do
     job = "{ \"queue\": \"default\", \"class\": \"#{class}\", \"args\": #{args} }"
 
     work_table = :ets.new(:work_table, [:set, :public])
-    {:ok, stub_server} = WorkerTest.MockServer.start_link()
-    {:ok, mock_stats_server} = GenServer.start_link(WorkerTest.MockStatsServer, %{})
-    {:ok, middleware} = GenServer.start_link(Exq.Middleware.Server, [])
-    {:ok, metadata} = Exq.Worker.Metadata.start_link(%{})
+
+    {:ok, stub_server} =
+      start_supervised(%{
+        id: WorkerTest.MockServer,
+        start: {WorkerTest.MockServer, :start_link, []}
+      })
+
+    {:ok, mock_stats_server} =
+      start_supervised(%{
+        id: WorkerTest.MockStatsServer,
+        start: {GenServer, :start_link, [WorkerTest.MockStatsServer, %{}]}
+      })
+
+    {:ok, middleware} =
+      start_supervised(%{
+        id: Exq.Middleware.Server,
+        start: {GenServer, :start_link, [Exq.Middleware.Server, []]}
+      })
+
+    {:ok, metadata} =
+      start_supervised(%{
+        id: Exq.Worker.Metadata,
+        start: {Exq.Worker.Metadata, :start_link, [%{}]}
+      })
+
     Exq.Middleware.Server.push(middleware, Exq.Middleware.Stats)
     Exq.Middleware.Server.push(middleware, Exq.Middleware.Job)
     Exq.Middleware.Server.push(middleware, Exq.Middleware.Manager)
     Exq.Middleware.Server.push(middleware, Exq.Middleware.Logger)
 
-    Exq.Worker.Server.start_link(
-      job,
-      stub_server,
-      "default",
-      work_table,
-      mock_stats_server,
-      "exq",
-      "localhost",
-      stub_server,
-      middleware,
-      metadata
-    )
+    start_supervised(%{
+      id: Exq.Worker.Server,
+      start:
+        {Exq.Worker.Server, :start_link,
+         [
+           job,
+           stub_server,
+           "default",
+           work_table,
+           mock_stats_server,
+           "exq",
+           "localhost",
+           stub_server,
+           middleware,
+           metadata
+         ]}
+    })
   end
 
   test "execute valid job with perform" do


### PR DESCRIPTION
Currently, unfinished jobs from backup queue get re-enqueued to the
end of job queue. This commit changes the behaviour and re-enqueue
the jobs to the front of the job queue so they will get picked up soon
after restart.

fixes #300 