### PR TITLE
use lua script to schedule jobs

### DIFF
--- a/lib/exq/support/config.ex
+++ b/lib/exq/support/config.ex
@@ -15,6 +15,7 @@ defmodule Exq.Support.Config do
     scheduler_enable: true,
     concurrency: 100,
     scheduler_poll_timeout: 200,
+    scheduler_page_size: 10,
     poll_timeout: 100,
     genserver_timeout: 5000,
     shutdown_timeout: 5000,

--- a/test/job_queue_test.exs
+++ b/test/job_queue_test.exs
@@ -207,6 +207,22 @@ defmodule JobQueueTest do
     assert_dequeue_job(["default"], false)
   end
 
+  test "scheduler_dequeue dequeues more than 10 jobs " do
+    now = DateTime.utc_now()
+
+    for _ <- 1..15 do
+      JobQueue.enqueue_at(:testredis, "test", "default", now, MyWorker, [], [])
+    end
+
+    assert JobQueue.scheduler_dequeue(:testredis, "test") == 15
+
+    for _ <- 1..15 do
+      assert_dequeue_job(["default"], true)
+    end
+
+    assert_dequeue_job(["default"], false)
+  end
+
   test "full_key" do
     assert JobQueue.full_key("exq", "k1") == "exq:k1"
     assert JobQueue.full_key("", "k1") == "k1"


### PR DESCRIPTION
The old approach had two issues

* There was no limit on the zrangebyscore call, this could potentially
cause memory issues if there are lot of jobs scheduled within the
current time range.

* The dequeue and enqueue operation is not atomic. The job could be
lost if exq failed to enqueue the job after the zrem command either
due to shutdown or redis connection error

The new approach uses lua script to run the dequeue and enqueue
atomically. A configurable page limit is used to avoid blocking the
redis server for long time.

fixes #318 #315