### PR TITLE
make it possible to use sentinel with latest redix

### DIFF
--- a/lib/exq/manager/server.ex
+++ b/lib/exq/manager/server.ex
@@ -436,13 +436,13 @@ defmodule Exq.Manager.Server do
         )
     catch
       err, reason ->
-        opts = Exq.Support.Opts.redis_opts(opts) |> List.wrap() |> List.delete(:password)
+        opts = Exq.Support.Opts.redis_inspect_opts(opts)
 
         raise """
         \n\n\n#{String.duplicate("=", 100)}
         ERROR! Could not connect to Redis!
 
-        Configuration passed in: #{inspect(opts)}
+        Configuration passed in: #{opts}
         Error: #{inspect(err)}
         Reason: #{inspect(reason)}
 

--- a/lib/exq/support/opts.ex
+++ b/lib/exq/support/opts.ex
@@ -75,10 +75,26 @@ defmodule Exq.Support.Opts do
   end
 
   defp mask_password(options) do
-    if Keyword.has_key?(options, :password) do
-      Keyword.update!(options, :password, fn
-        nil -> nil
-        _ -> "*****"
+    options =
+      if Keyword.has_key?(options, :password) do
+        Keyword.update!(options, :password, fn
+          nil -> nil
+          _ -> "*****"
+        end)
+      else
+        options
+      end
+
+    options =
+      if Keyword.has_key?(options, :sentinel) do
+        Keyword.update!(options, :sentinel, &mask_password/1)
+      else
+        options
+      end
+
+    if Keyword.has_key?(options, :sentinels) do
+      Keyword.update!(options, :sentinels, fn sentinels ->
+        Enum.map(sentinels, &mask_password/1)
       end)
     else
       options

--- a/lib/exq/support/opts.ex
+++ b/lib/exq/support/opts.ex
@@ -25,6 +25,16 @@ defmodule Exq.Support.Opts do
     "#{name}.Redis.Client" |> String.to_atom()
   end
 
+  def redis_inspect_opts(opts \\ []) do
+    args = redis_opts(opts)
+
+    case args do
+      [url, options] -> [url, mask_password(options)]
+      [options] -> [mask_password(options)]
+    end
+    |> inspect()
+  end
+
   def redis_opts(opts \\ []) do
     redis_options = opts[:redis_options] || Config.get(:redis_options)
     socket_opts = opts[:socket_opts] || Config.get(:socket_opts) || []
@@ -62,6 +72,17 @@ defmodule Exq.Support.Opts do
   def redis_worker_opts(opts) do
     {redis_opts, opts} = conform_opts(opts)
     {Redix, redis_opts, opts}
+  end
+
+  defp mask_password(options) do
+    if Keyword.has_key?(options, :password) do
+      Keyword.update!(options, :password, fn
+        nil -> nil
+        _ -> "*****"
+      end)
+    else
+      options
+    end
   end
 
   defp server_opts(:default, opts) do

--- a/mix.lock
+++ b/mix.lock
@@ -19,7 +19,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm", "5c040b8469c1ff1b10093d3186e2e10dbe483cd73d79ec017993fb3985b8a9b3"},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], [], "hexpm", "002caaf939b97c84533ef0f621d3ed414ed703fcd03c91ec0dd62043df102c63"},
   "ranch": {:hex, :ranch, "1.7.0", "9583f47160ca62af7f8d5db11454068eaa32b56eeadf984d4f46e61a076df5f2", [:rebar3], [], "hexpm", "59f7501c3a56125b2fc5684c3048fac9d043c0bf4d173941b12ca927949af189"},
-  "redix": {:hex, :redix, "0.11.2", "f6c696928bc0c81f9a04ea53299c353f7552ae3f4c5d1e884f3a6257098b9d66", [:mix], [{:castore, "~> 0.1.0", [hex: :castore, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "ae74e25026c4a0d17cad3c12814b313b28ac4277f3725220ae1df2f96320c38d"},
+  "redix": {:hex, :redix, "0.10.2", "a9eabf47898aa878650df36194aeb63966d74f5bd69d9caa37babb32dbb93c5d", [:mix], [{:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "251b329893b8f6bb115fc0e30df7f12ee641b1e4547d760cf0909416a209f9bd"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm", "4f8805eb5c8a939cf2359367cb651a3180b27dfb48444846be2613d79355d65e"},
   "telemetry": {:hex, :telemetry, "0.4.2", "2808c992455e08d6177322f14d3bdb6b625fbcfd233a73505870d8738a2f4599", [:rebar3], [], "hexpm", "2d1419bd9dda6a206d7b5852179511722e2b18812310d304620c7bd92a13fcef"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -19,7 +19,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm", "5c040b8469c1ff1b10093d3186e2e10dbe483cd73d79ec017993fb3985b8a9b3"},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], [], "hexpm", "002caaf939b97c84533ef0f621d3ed414ed703fcd03c91ec0dd62043df102c63"},
   "ranch": {:hex, :ranch, "1.7.0", "9583f47160ca62af7f8d5db11454068eaa32b56eeadf984d4f46e61a076df5f2", [:rebar3], [], "hexpm", "59f7501c3a56125b2fc5684c3048fac9d043c0bf4d173941b12ca927949af189"},
-  "redix": {:hex, :redix, "0.10.2", "a9eabf47898aa878650df36194aeb63966d74f5bd69d9caa37babb32dbb93c5d", [:mix], [{:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "251b329893b8f6bb115fc0e30df7f12ee641b1e4547d760cf0909416a209f9bd"},
+  "redix": {:hex, :redix, "0.11.2", "f6c696928bc0c81f9a04ea53299c353f7552ae3f4c5d1e884f3a6257098b9d66", [:mix], [{:castore, "~> 0.1.0", [hex: :castore, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "ae74e25026c4a0d17cad3c12814b313b28ac4277f3725220ae1df2f96320c38d"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm", "4f8805eb5c8a939cf2359367cb651a3180b27dfb48444846be2613d79355d65e"},
   "telemetry": {:hex, :telemetry, "0.4.2", "2808c992455e08d6177322f14d3bdb6b625fbcfd233a73505870d8738a2f4599", [:rebar3], [], "hexpm", "2d1419bd9dda6a206d7b5852179511722e2b18812310d304620c7bd92a13fcef"},
 }

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -130,6 +130,60 @@ defmodule Exq.ConfigTest do
     assert client_name == Exq.Redis
   end
 
+  test "redis_inspect_opts" do
+    Mix.Config.persist(exq: [host: "127.0.0.1", port: 6379, password: 'password', database: 0])
+
+    assert "[[host: \"127.0.0.1\", port: 6379, database: 0, password: \"*****\", name: Exq.Redis, socket_opts: []]]" ==
+             Exq.Support.Opts.redis_inspect_opts(redis: Exq.Redis)
+
+    Mix.Config.persist(exq: [host: '127.1.1.1', password: 'password'])
+
+    assert "[[host: '127.1.1.1', port: 6379, database: 0, password: \"*****\", name: Exq.Redis, socket_opts: []]]" ==
+             Exq.Support.Opts.redis_inspect_opts(redis: Exq.Redis)
+
+    Mix.Config.persist(exq: [password: nil])
+
+    assert "[[host: '127.1.1.1', port: 6379, database: 0, password: nil, name: nil, socket_opts: []]]" ==
+             Exq.Support.Opts.redis_inspect_opts()
+
+    Mix.Config.persist(exq: [url: "redis_url"])
+
+    assert "[\"redis_url\", [name: Exq.Redis, socket_opts: []]]" ==
+             Exq.Support.Opts.redis_inspect_opts(redis: Exq.Redis)
+
+    Mix.Config.persist(
+      exq: [
+        redis_options: [
+          sentinel: [sentinels: [[host: "127.0.0.1", port: 6666]], group: "exq"],
+          database: 0,
+          password: "password",
+          timeout: 5000,
+          name: Exq.Redis.Client,
+          socket_opts: []
+        ]
+      ]
+    )
+
+    assert "[\"redis_url\", [sentinel: [sentinels: [[host: \"127.0.0.1\", port: 6666]], group: \"exq\"], database: 0, password: \"*****\", timeout: 5000, name: Exq.Redis.Client, socket_opts: []]]" ==
+             Exq.Support.Opts.redis_inspect_opts(redis: Exq.Redis)
+
+    Mix.Config.persist(
+      exq: [
+        redis_options: [
+          sentinel: [sentinels: [[host: "127.0.0.1", port: 6666]], group: "exq"],
+          database: 0,
+          password: nil,
+          timeout: 5000,
+          name: Exq.Redis.Client,
+          socket_opts: []
+        ]
+      ]
+    )
+
+    assert "[\"redis_url\", [sentinel: [sentinels: [[host: \"127.0.0.1\", port: 6666]], group: \"exq\"], database: 0, password: nil, timeout: 5000, name: Exq.Redis.Client, socket_opts: []]]" ==
+             Exq.Support.Opts.redis_inspect_opts(redis: Exq.Redis)
+  end
+
   test "default redis_worker_opts" do
     Mix.Config.persist(
       exq: [

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -182,6 +182,43 @@ defmodule Exq.ConfigTest do
 
     assert "[\"redis_url\", [sentinel: [sentinels: [[host: \"127.0.0.1\", port: 6666]], group: \"exq\"], database: 0, password: nil, timeout: 5000, name: Exq.Redis.Client, socket_opts: []]]" ==
              Exq.Support.Opts.redis_inspect_opts(redis: Exq.Redis)
+
+    Mix.Config.persist(
+      exq: [
+        redis_options: [
+          sentinel: [
+            sentinels: [[host: "127.0.0.1", port: 6666]],
+            password: "password",
+            group: "exq"
+          ],
+          database: 0,
+          timeout: 5000,
+          name: Exq.Redis.Client,
+          socket_opts: []
+        ]
+      ]
+    )
+
+    assert "[\"redis_url\", [sentinel: [sentinels: [[host: \"127.0.0.1\", port: 6666]], password: \"*****\", group: \"exq\"], database: 0, timeout: 5000, name: Exq.Redis.Client, socket_opts: []]]" ==
+             Exq.Support.Opts.redis_inspect_opts(redis: Exq.Redis)
+
+    Mix.Config.persist(
+      exq: [
+        redis_options: [
+          sentinel: [
+            sentinels: [[host: "127.0.0.1", port: 6666, password: "password"]],
+            group: "exq"
+          ],
+          database: 0,
+          timeout: 5000,
+          name: Exq.Redis.Client,
+          socket_opts: []
+        ]
+      ]
+    )
+
+    assert "[\"redis_url\", [sentinel: [sentinels: [[host: \"127.0.0.1\", port: 6666, password: \"*****\"]], group: \"exq\"], database: 0, timeout: 5000, name: Exq.Redis.Client, socket_opts: []]]" ==
+             Exq.Support.Opts.redis_inspect_opts(redis: Exq.Redis)
   end
 
   test "default redis_worker_opts" do


### PR DESCRIPTION
redix added stricter config validation on 0.11.0. It doesn't allow
host/port config if sentinel option is present.

[1] https://github.com/whatyouhide/redix/commit/4ca9146db158d2918e7399e5881ae1aa349fb79f