### PR TITLE
Changing Log level to warn for job errors

### DIFF
--- a/lib/exq/middleware/logger.ex
+++ b/lib/exq/middleware/logger.ex
@@ -16,8 +16,8 @@ defmodule Exq.Middleware.Logger do
   end
 
   def after_failed_work(pipeline) do
-    Logger.info(to_string(pipeline.assigns.error_message))
-    Logger.info("#{log_context(pipeline)} fail: #{formatted_diff(delta(pipeline))}")
+    Logger.warn(to_string(pipeline.assigns.error_message))
+    Logger.warn("#{log_context(pipeline)} fail: #{formatted_diff(delta(pipeline))}")
     pipeline
   end
 


### PR DESCRIPTION
Logging everything as info makes it hard to use the log level configuration when we only care about getting logs for errors.

Since these are recoverable errors the warning level makes the most sense to me.