### PR TITLE
use Task instead of spawn_link for starting workers

### DIFF
--- a/lib/exq/worker/server.ex
+++ b/lib/exq/worker/server.ex
@@ -172,8 +172,8 @@ defmodule Exq.Worker.Server do
     Process.flag(:trap_exit, true)
     worker = self()
 
-    pid =
-      spawn_link(fn ->
+    {:ok, pid} =
+      Task.start_link(fn ->
         :ok = Metadata.associate(metadata, self(), job)
         result = apply(worker_module, :perform, job.args)
         GenServer.cast(worker, {:done, result})


### PR DESCRIPTION
Hello! 👋🏼 

I maintain https://github.com/getsentry/sentry-elixir and have received issues where failed jobs in Exq don't report process metadata from the crashed process (https://github.com/getsentry/sentry-elixir/issues/349). It looks like it's due to using `spawn_link` instead of Elixir modules like Task or GenServer that rely on `:proc_lib` underneath. The change would allow for some more detailed reporting on the state of the worker process is in when it crashed, including parent process, metadata, and more.

I wasn't sure if `Task` was appropriate, but the tests do pass 🙂 