### PR TITLE
Improve Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,103 @@
-on: [pull_request, push]
+name: Test
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+
 jobs:
-  test:
+  check_duplicate_runs:
+    name: Check for duplicate runs
+    continue-on-error: true
     runs-on: ubuntu-latest
-    env:
-      MIX_ENV: test
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: always
+          cancel_others: true
+          skip_after_successful_duplicate: true
+          paths_ignore: '["**/README.md", "**/CHANGELOG.md", "**/LICENSE"]'
+          do_not_skip: '["pull_request"]'
+
+  test:
+    name: Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }}
+    runs-on: ubuntu-18.04
+    needs: check_duplicate_runs
+    if: ${{ needs.check_duplicate_runs.outputs.should_skip != 'true' }}
+
     strategy:
       matrix:
-        include:
-          - elixir: 1.6
-            otp: 20.3
-          - elixir: 1.7
-            otp: 21.3
-          - elixir: 1.8.2
-            otp: 21.3
-          - elixir: 1.9.4
-            otp: 22.2
-          - elixir: 1.10.4
-            otp: 23.0
+        elixir:
+        - "1.6"
+        - "1.7"
+        - "1.8.2"
+        - "1.9.4"
+        - "1.10.4"
+        - "1.11.3"
+        otp:
+        - "20.3"
+        - "21.3"
+        - "22.2"
+        - "23.0"
+        exclude:
+        - elixir: "1.6"
+          otp: "21.3"
+        - elixir: "1.6"
+          otp: "22.2"
+        - elixir: "1.6"
+          otp: "23.0"
+        - elixir: "1.10.4"
+          otp: "20.3"
+        - elixir: "1.11.3"
+          otp: "20.3"
+
     steps:
-      - run: sudo apt-get install redis-server -y
-      - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1
-        with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
-      - run: mix deps.get
-      - run: mix compile --force --warnings-as-errors
-      - run: mix coveralls.github --no-start
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Elixir
+      uses: erlef/setup-elixir@v1
+      with:
+        elixir-version: ${{ matrix.elixir }}
+        otp-version: ${{ matrix.otp }}
+
+    - name: Set up Redis Server
+      run: sudo apt-get install redis-server -y
+
+    - name: Restore deps cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          deps
+          _build
+        key: ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}-git-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          ${{ runner.os }}-deps-${{ matrix.otp }}-${{ matrix.elixir }}
+
+    - name: Install package dependencies
+      run: mix deps.get
+
+    - name: Remove compiled application files
+      run: mix clean
+
+    - name: Compile dependencies
+      run: mix compile
+      env:
+        MIX_ENV: test
+
+    - name: Compile dependencies
+      run: mix compile --force --warnings-as-errors
+      if: matrix.elixir != '1.11.3'
+      env:
+        MIX_ENV: test
+
+    - name: Run unit tests
+      run: mix coveralls.github --no-start
+      env:
+        MIX_ENV: test
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hello.

I have some improvement of the CI pipeline you have.

FIrstly, ubuntu-latest version was recently upgraded from 18.04 to 20.04. This causes an error with Elixir installation step:
https://github.com/akira/exq/pull/442/checks?check_run_id=2131663989
So I've changed ubuntu version back to 18.04 until the installer will be updated. 18.04 will be supported until April 2023.

Secondly, there is an annoying fact about Github Actions - sometimes it runs actions twice. For example:
1. You just pushed a commit to a branch - testing workflow will run only once
2. Someone forked your repo and creates a pull request - same thing
3. You've created a new branch (feature, bugfix or release branch), pushed a commit here and also created a pull request to the main branch - two copies of workflow will be run

Running a workflow twice does not make any sense, it just takes twice the time without any useful side effect.

So in this PR I've also added a separated job of checking if another copy of workflow already started: https://github.com/fkirc/skip-duplicate-actions

This job allows to:
1. Skip the second copy of workflow in the case 3 (branch in original repo + PR to main branch). Cases 1 and 2 will work just the same as now
2. Skip workflow if someone changed only files which are not connected to package code, like README or CHANGELOG
3. Cancel already started workflow in the same PR or branch if someone pushed new commits to it.

Thirdly, I've added caching step for deps and build temp files to speed up CI process.
Fourthly, I've added latest Elixir version 1.11 into the build matrix.

Example of job run:
https://github.com/dolfinus/exq/actions/runs/674056926

What do you think about that?