### PR TITLE
handle timeouts on middleware pipeline

### DIFF
--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -104,8 +104,8 @@ defmodule Exq.Redis.Connection do
     q(redis, ["LPOP", key])
   end
 
-  def zadd(redis, set, score, member) do
-    q(redis, ["ZADD", set, score, member])
+  def zadd(redis, set, score, member, options \\ []) do
+    q(redis, ["ZADD", set, score, member], options)
   end
 
   def zadd!(redis, set, score, member) do

--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -6,6 +6,7 @@ defmodule Exq.Redis.Connection do
   require Logger
 
   alias Exq.Support.Config
+  alias Exq.Support.Redis
 
   def flushdb!(redis) do
     {:ok, res} = q(redis, ["flushdb"])
@@ -84,8 +85,8 @@ defmodule Exq.Redis.Connection do
     items
   end
 
-  def lrem!(redis, list, value, count \\ 1) do
-    {:ok, res} = q(redis, ["LREM", list, count, value])
+  def lrem!(redis, list, value, count \\ 1, options \\ []) do
+    {:ok, res} = q(redis, ["LREM", list, count, value], options)
     res
   end
 
@@ -154,22 +155,37 @@ defmodule Exq.Redis.Connection do
     q(redis, ["ZREM", set, member])
   end
 
-  def q(redis, command) do
-    redis
-    |> Redix.command(command, timeout: Config.get(:redis_timeout))
-    |> handle_response(redis)
+  def q(redis, command, options \\ []) do
+    Redis.with_retry_on_connection_error(
+      fn ->
+        redis
+        |> Redix.command(command, timeout: Config.get(:redis_timeout))
+        |> handle_response(redis)
+      end,
+      Keyword.get(options, :retry_on_connection_error, 0)
+    )
   end
 
-  def qp(redis, command) do
-    redis
-    |> Redix.pipeline(command, timeout: Config.get(:redis_timeout))
-    |> handle_responses(redis)
+  def qp(redis, command, options \\ []) do
+    Redis.with_retry_on_connection_error(
+      fn ->
+        redis
+        |> Redix.pipeline(command, timeout: Config.get(:redis_timeout))
+        |> handle_responses(redis)
+      end,
+      Keyword.get(options, :retry_on_connection_error, 0)
+    )
   end
 
-  def qp!(redis, command) do
-    redis
-    |> Redix.pipeline!(command, timeout: Config.get(:redis_timeout))
-    |> handle_responses(redis)
+  def qp!(redis, command, options \\ []) do
+    Redis.with_retry_on_connection_error(
+      fn ->
+        redis
+        |> Redix.pipeline!(command, timeout: Config.get(:redis_timeout))
+        |> handle_responses(redis)
+      end,
+      Keyword.get(options, :retry_on_connection_error, 0)
+    )
   end
 
   defp handle_response({:error, %{message: "READONLY" <> _rest}} = error, redis) do

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -150,7 +150,9 @@ defmodule Exq.Redis.JobQueue do
   end
 
   def remove_job_from_backup(redis, namespace, node_id, queue, job_serialized) do
-    Connection.lrem!(redis, backup_queue_key(namespace, node_id, queue), job_serialized)
+    Connection.lrem!(redis, backup_queue_key(namespace, node_id, queue), job_serialized, 1,
+      retry_on_connection_error: 3
+    )
   end
 
   def scheduler_dequeue(redis, namespace) do

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -250,12 +250,14 @@ defmodule Exq.Redis.JobQueue do
     offset = Config.backoff().offset(job)
     time = Time.offset_from_now(offset)
     Logger.info("Queueing job #{job.jid} to retry in #{offset} seconds")
-    enqueue_job_at(redis, namespace, Job.encode(job), job.jid, time, retry_queue_key(namespace))
+
+    {:ok, _jid} =
+      enqueue_job_at(redis, namespace, Job.encode(job), job.jid, time, retry_queue_key(namespace))
   end
 
   def retry_job(redis, namespace, job) do
     remove_retry(redis, namespace, job.jid)
-    enqueue(redis, namespace, Job.encode(job))
+    {:ok, _jid} = enqueue(redis, namespace, Job.encode(job))
   end
 
   def fail_job(redis, namespace, job, error) do

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -75,7 +75,9 @@ defmodule Exq.Redis.JobQueue do
     score = Time.time_to_score(time)
 
     try do
-      case Connection.zadd(redis, scheduled_queue, score, job_serialized) do
+      case Connection.zadd(redis, scheduled_queue, score, job_serialized,
+             retry_on_connection_error: 3
+           ) do
         {:ok, _} -> {:ok, jid}
         other -> other
       end
@@ -280,7 +282,7 @@ defmodule Exq.Redis.JobQueue do
       ["ZREMRANGEBYRANK", key, 0, -Config.get(:dead_max_jobs) - 1]
     ]
 
-    Connection.qp!(redis, commands)
+    Connection.qp!(redis, commands, retry_on_connection_error: 3)
   end
 
   def queue_size(redis, namespace) do

--- a/lib/exq/support/redis.ex
+++ b/lib/exq/support/redis.ex
@@ -1,0 +1,37 @@
+defmodule Exq.Support.Redis do
+  require Logger
+
+  @doc """
+  Rescue GenServer timeout.
+  """
+  def rescue_timeout(f, options \\ []) do
+    try do
+      f.()
+    catch
+      :exit, {:timeout, info} ->
+        Logger.info("Manager timeout occurred #{inspect(info)}")
+        Keyword.get(options, :timeout_return_value, nil)
+    end
+  end
+
+  def with_retry_on_connection_error(f, times) when times <= 0 do
+    f.()
+  end
+
+  def with_retry_on_connection_error(f, times) when times > 0 do
+    try do
+      case f.() do
+        {:error, %Redix.ConnectionError{} = exception} ->
+          Logger.error("Retrying redis connection error: #{inspect(exception)}")
+          with_retry_on_connection_error(f, times - 1)
+
+        result ->
+          result
+      end
+    rescue
+      exception in [Redix.ConnectionError] ->
+        Logger.error("Retrying redis connection error: #{inspect(exception)}")
+        with_retry_on_connection_error(f, times - 1)
+    end
+  end
+end


### PR DESCRIPTION
Currently, if any of the middleware fails, (notably
Exq.Middleware.Job), it prevents the execution of remaining
middlewares. This is highly problematic as Exq.Middleware.Manager is
essential for Exq to function properly.

In this specific case, if the redis operation in Exq.Middleware.Job
timeouts (or fails), then Exq fails to decrement the busy worker count
and with enough number of such failures, the worker eventually will
stop picking up new jobs.

This commit tries to improve the conditions by adding a retry for
`remove_job_from_backup` operation. Retrying is ok in this case as the
operation is idempotent