### PR TITLE
Add apis to support exq_ui

### DIFF
--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -293,6 +293,10 @@ defmodule Exq.Api do
     GenServer.call(pid, {:remove_retry, jid})
   end
 
+  def remove_retry_job(pid, raw_job) do
+    GenServer.call(pid, {:remove_retry_job, raw_job})
+  end
+
   def clear_retries(pid) do
     GenServer.call(pid, :clear_retries)
   end

--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -169,7 +169,7 @@ defmodule Exq.Api do
     * `:ok`
 
   """
-  @deprecated "use remove_enqueued_job/3"
+  @deprecated "use remove_enqueued_jobs/3"
   def remove_job(pid, queue, jid) do
     GenServer.call(pid, {:remove_job, queue, jid})
   end
@@ -186,8 +186,8 @@ defmodule Exq.Api do
     * `:ok`
 
   """
-  def remove_enqueued_job(pid, queue, raw_job) do
-    GenServer.call(pid, {:remove_enqueued_job, queue, raw_job})
+  def remove_enqueued_jobs(pid, queue, raw_jobs) do
+    GenServer.call(pid, {:remove_enqueued_jobs, queue, raw_jobs})
   end
 
   @doc """

--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -301,6 +301,24 @@ defmodule Exq.Api do
   end
 
   @doc """
+  Find job in retry queue
+
+  Expected args:
+    * `pid` - Exq.Api process
+    * `score` - Job score
+    * `jid` - Job jid
+    * `options`
+      - raw: (boolean) whether to deserialize the job
+
+  Returns:
+    * `{:ok, job}`
+
+  """
+  def find_retry(pid, score, jid, options \\ []) do
+    GenServer.call(pid, {:find_retry, score, jid, options})
+  end
+
+  @doc """
   Removes a job in the retry queue from being enqueued again.
 
   Expected args:

--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -256,6 +256,10 @@ defmodule Exq.Api do
     GenServer.call(pid, {:remove_failed, jid})
   end
 
+  def remove_failed_jobs(pid, raw_jobs) do
+    GenServer.call(pid, {:remove_failed_jobs, raw_jobs})
+  end
+
   def clear_failed(pid) do
     GenServer.call(pid, :clear_failed)
   end

--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -293,8 +293,8 @@ defmodule Exq.Api do
     GenServer.call(pid, {:remove_retry, jid})
   end
 
-  def remove_retry_job(pid, raw_job) do
-    GenServer.call(pid, {:remove_retry_job, raw_job})
+  def remove_retry_jobs(pid, raw_jobs) do
+    GenServer.call(pid, {:remove_retry_jobs, raw_jobs})
   end
 
   def clear_retries(pid) do

--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -334,6 +334,10 @@ defmodule Exq.Api do
     GenServer.call(pid, {:remove_scheduled, jid})
   end
 
+  def remove_scheduled_jobs(pid, raw_jobs) do
+    GenServer.call(pid, {:remove_scheduled_jobs, raw_jobs})
+  end
+
   def clear_scheduled(pid) do
     GenServer.call(pid, :clear_scheduled)
   end

--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -90,13 +90,17 @@ defmodule Exq.Api do
   Expected args:
     * `pid` - Exq.Api process
     * `queue` - Queue name
+    * `options`
+      - size: (integer) size of list
+      - offset: (integer) start offset of the list
+      - raw: (boolean) whether to deserialize the job
 
   Returns:
     * `{:ok, [jobs]}`
 
   """
-  def jobs(pid, queue) do
-    GenServer.call(pid, {:jobs, queue})
+  def jobs(pid, queue, options \\ []) do
+    GenServer.call(pid, {:jobs, queue, options})
   end
 
   @doc """
@@ -104,13 +108,17 @@ defmodule Exq.Api do
 
   Expected args:
     * `pid` - Exq.Api process
+    * `options`
+      - score: (boolean) whether to include job score
+      - size: (integer) size of list
+      - offset: (integer) start offset of the list
 
   Returns:
     * `{:ok, [jobs]}`
 
   """
-  def retries(pid) do
-    GenServer.call(pid, :retries)
+  def retries(pid, options \\ []) do
+    GenServer.call(pid, {:retries, options})
   end
 
   @doc """
@@ -118,13 +126,17 @@ defmodule Exq.Api do
 
   Expected args:
     * `pid` - Exq.Api process
+    * `options`
+      - score: (boolean) whether to include job score
+      - size: (integer) size of list
+      - offset: (integer) start offset of the list
 
   Returns:
     * `{:ok, [jobs]}`
 
   """
-  def scheduled(pid) do
-    GenServer.call(pid, {:jobs, :scheduled})
+  def scheduled(pid, options \\ []) do
+    GenServer.call(pid, {:jobs, :scheduled, options})
   end
 
   @doc """
@@ -157,8 +169,25 @@ defmodule Exq.Api do
     * `:ok`
 
   """
+  @deprecated "use remove_enqueued_job/3"
   def remove_job(pid, queue, jid) do
     GenServer.call(pid, {:remove_job, queue, jid})
+  end
+
+  @doc """
+  Removes a job from the queue specified.
+
+  Expected args:
+    * `pid` - Exq.Api process
+    * `queue` - The name of the queue to remove the job from
+    * `raw_job` - raw json encoded job value
+
+  Returns:
+    * `:ok`
+
+  """
+  def remove_enqueued_job(pid, queue, raw_job) do
+    GenServer.call(pid, {:remove_enqueued_job, queue, raw_job})
   end
 
   @doc """
@@ -195,13 +224,17 @@ defmodule Exq.Api do
 
   Expected args:
     * `pid` - Exq.Api process
+    * `options`
+      - score: (boolean) whether to include job score
+      - size: (integer) size of list
+      - offset: (integer) start offset of the list
 
   Returns:
     * `{:ok, [jobs]}`
 
   """
-  def failed(pid) do
-    GenServer.call(pid, :failed)
+  def failed(pid, options \\ []) do
+    GenServer.call(pid, {:failed, options})
   end
 
   def find_failed(pid, jid) do

--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -242,6 +242,24 @@ defmodule Exq.Api do
   end
 
   @doc """
+  Find failed job
+
+  Expected args:
+    * `pid` - Exq.Api process
+    * `score` - Job score
+    * `jid` - Job jid
+    * `options`
+      - raw: (boolean) whether to deserialize the job
+
+  Returns:
+    * `{:ok, job}`
+
+  """
+  def find_failed(pid, score, jid, options \\ []) do
+    GenServer.call(pid, {:find_failed, score, jid, options})
+  end
+
+  @doc """
   Removes a job in the queue of jobs that have failed and exceeded their retry count.
 
   Expected args:

--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -360,6 +360,24 @@ defmodule Exq.Api do
   end
 
   @doc """
+  Find job in scheduled queue
+
+  Expected args:
+    * `pid` - Exq.Api process
+    * `score` - Job score
+    * `jid` - Job jid
+    * `options`
+      - raw: (boolean) whether to deserialize the job
+
+  Returns:
+    * `{:ok, job}`
+
+  """
+  def find_scheduled(pid, score, jid, options \\ []) do
+    GenServer.call(pid, {:find_scheduled, score, jid, options})
+  end
+
+  @doc """
   Removes a job scheduled to run in the future from being enqueued.
 
   Expected args:

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -125,6 +125,11 @@ defmodule Exq.Api.Server do
     {:reply, {:ok, job}, state}
   end
 
+  def handle_call({:find_scheduled, score, jid, options}, _from, state) do
+    {:ok, job} = JobStat.find_scheduled(state.redis, state.namespace, score, jid, options)
+    {:reply, {:ok, job}, state}
+  end
+
   def handle_call({:find_retry, jid}, _from, state) do
     {:ok, job} = JobQueue.find_job(state.redis, state.namespace, jid, :retry)
     {:reply, {:ok, job}, state}

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -110,6 +110,11 @@ defmodule Exq.Api.Server do
     {:reply, {:ok, job}, state}
   end
 
+  def handle_call({:find_failed, score, jid, options}, _from, state) do
+    {:ok, job} = JobStat.find_failed(state.redis, state.namespace, score, jid, options)
+    {:reply, {:ok, job}, state}
+  end
+
   def handle_call({:find_job, queue, jid}, _from, state) do
     response = JobQueue.find_job(state.redis, state.namespace, jid, queue)
     {:reply, response, state}

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -165,6 +165,11 @@ defmodule Exq.Api.Server do
     {:reply, :ok, state}
   end
 
+  def handle_call({:remove_failed_jobs, raw_jobs}, _from, state) do
+    JobQueue.remove_failed_jobs(state.redis, state.namespace, raw_jobs)
+    {:reply, :ok, state}
+  end
+
   def handle_call(:clear_failed, _from, state) do
     JobStat.clear_failed(state.redis, state.namespace)
     {:reply, :ok, state}

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -145,6 +145,11 @@ defmodule Exq.Api.Server do
     {:reply, :ok, state}
   end
 
+  def handle_call({:remove_retry_job, raw_job}, _from, state) do
+    JobQueue.remove_retry_job(state.redis, state.namespace, raw_job)
+    {:reply, :ok, state}
+  end
+
   def handle_call({:remove_scheduled, jid}, _from, state) do
     JobQueue.remove_scheduled(state.redis, state.namespace, jid)
     {:reply, :ok, state}

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -135,8 +135,8 @@ defmodule Exq.Api.Server do
     {:reply, :ok, state}
   end
 
-  def handle_call({:remove_enqueued_job, queue, raw_job}, _from, state) do
-    JobQueue.remove_enqueued_job(state.redis, state.namespace, queue, raw_job)
+  def handle_call({:remove_enqueued_jobs, queue, raw_jobs}, _from, state) do
+    JobQueue.remove_enqueued_jobs(state.redis, state.namespace, queue, raw_jobs)
     {:reply, :ok, state}
   end
 

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -130,6 +130,11 @@ defmodule Exq.Api.Server do
     {:reply, {:ok, job}, state}
   end
 
+  def handle_call({:find_retry, score, jid, options}, _from, state) do
+    {:ok, job} = JobStat.find_retry(state.redis, state.namespace, score, jid, options)
+    {:reply, {:ok, job}, state}
+  end
+
   def handle_call({:remove_queue, queue}, _from, state) do
     JobStat.remove_queue(state.redis, state.namespace, queue)
     {:reply, :ok, state}

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -145,8 +145,8 @@ defmodule Exq.Api.Server do
     {:reply, :ok, state}
   end
 
-  def handle_call({:remove_retry_job, raw_job}, _from, state) do
-    JobQueue.remove_retry_job(state.redis, state.namespace, raw_job)
+  def handle_call({:remove_retry_jobs, raw_jobs}, _from, state) do
+    JobQueue.remove_retry_jobs(state.redis, state.namespace, raw_jobs)
     {:reply, :ok, state}
   end
 

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -155,6 +155,11 @@ defmodule Exq.Api.Server do
     {:reply, :ok, state}
   end
 
+  def handle_call({:remove_scheduled_jobs, raw_jobs}, _from, state) do
+    JobQueue.remove_scheduled_jobs(state.redis, state.namespace, raw_jobs)
+    {:reply, :ok, state}
+  end
+
   def handle_call({:remove_failed, jid}, _from, state) do
     JobStat.remove_failed(state.redis, state.namespace, jid)
     {:reply, :ok, state}

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -50,13 +50,13 @@ defmodule Exq.Api.Server do
     {:reply, {:ok, queues}, state}
   end
 
-  def handle_call(:failed, _from, state) do
-    jobs = JobQueue.failed(state.redis, state.namespace)
+  def handle_call({:failed, options}, _from, state) do
+    jobs = JobQueue.failed(state.redis, state.namespace, options)
     {:reply, {:ok, jobs}, state}
   end
 
-  def handle_call(:retries, _from, state) do
-    jobs = JobQueue.scheduled_jobs(state.redis, state.namespace, "retry")
+  def handle_call({:retries, options}, _from, state) do
+    jobs = JobQueue.scheduled_jobs(state.redis, state.namespace, "retry", options)
     {:reply, {:ok, jobs}, state}
   end
 
@@ -65,8 +65,8 @@ defmodule Exq.Api.Server do
     {:reply, {:ok, jobs}, state}
   end
 
-  def handle_call({:jobs, :scheduled}, _from, state) do
-    jobs = JobQueue.scheduled_jobs(state.redis, state.namespace, "schedule")
+  def handle_call({:jobs, :scheduled, options}, _from, state) do
+    jobs = JobQueue.scheduled_jobs(state.redis, state.namespace, "schedule", options)
     {:reply, {:ok, jobs}, state}
   end
 
@@ -75,8 +75,8 @@ defmodule Exq.Api.Server do
     {:reply, {:ok, jobs}, state}
   end
 
-  def handle_call({:jobs, queue}, _from, state) do
-    jobs = JobQueue.jobs(state.redis, state.namespace, queue)
+  def handle_call({:jobs, queue, options}, _from, state) do
+    jobs = JobQueue.jobs(state.redis, state.namespace, queue, options)
     {:reply, {:ok, jobs}, state}
   end
 
@@ -132,6 +132,11 @@ defmodule Exq.Api.Server do
 
   def handle_call({:remove_job, queue, jid}, _from, state) do
     JobQueue.remove_job(state.redis, state.namespace, queue, jid)
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:remove_enqueued_job, queue, raw_job}, _from, state) do
+    JobQueue.remove_enqueued_job(state.redis, state.namespace, queue, raw_job)
     {:reply, :ok, state}
   end
 

--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -156,6 +156,11 @@ defmodule Exq.Redis.Connection do
     items
   end
 
+  def zrem!(redis, set, members) when is_list(members) do
+    {:ok, res} = q(redis, ["ZREM", set | members])
+    res
+  end
+
   def zrem!(redis, set, member) do
     {:ok, res} = q(redis, ["ZREM", set, member])
     res

--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -158,6 +158,18 @@ defmodule Exq.Redis.Connection do
     q(redis, ["ZRANGEBYSCORE", set, min, max, "WITHSCORES"])
   end
 
+  def zrevrangebyscorewithlimit!(redis, set, offset, size, min \\ "0", max \\ "+inf") do
+    {:ok, items} = q(redis, ["ZREVRANGEBYSCORE", set, max, min, "LIMIT", offset, size])
+    items
+  end
+
+  def zrevrangebyscorewithscoreandlimit!(redis, set, offset, size, min \\ "0", max \\ "+inf") do
+    {:ok, items} =
+      q(redis, ["ZREVRANGEBYSCORE", set, max, min, "WITHSCORES", "LIMIT", offset, size])
+
+    items
+  end
+
   def zrange!(redis, set, range_start \\ "0", range_end \\ "-1") do
     {:ok, items} = q(redis, ["ZRANGE", set, range_start, range_end])
     items

--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -128,12 +128,22 @@ defmodule Exq.Redis.Connection do
     items
   end
 
+  def zrangebyscorewithlimit!(redis, set, offset, size, min \\ "0", max \\ "+inf") do
+    {:ok, items} = q(redis, ["ZRANGEBYSCORE", set, min, max, "LIMIT", offset, size])
+    items
+  end
+
   def zrangebyscore(redis, set, min \\ "0", max \\ "+inf") do
     q(redis, ["ZRANGEBYSCORE", set, min, max])
   end
 
   def zrangebyscorewithscore!(redis, set, min \\ "0", max \\ "+inf") do
     {:ok, items} = q(redis, ["ZRANGEBYSCORE", set, min, max, "WITHSCORES"])
+    items
+  end
+
+  def zrangebyscorewithscoreandlimit!(redis, set, offset, size, min \\ "0", max \\ "+inf") do
+    {:ok, items} = q(redis, ["ZRANGEBYSCORE", set, min, max, "WITHSCORES", "LIMIT", offset, size])
     items
   end
 

--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -86,7 +86,14 @@ defmodule Exq.Redis.Connection do
   end
 
   def lrem!(redis, list, value, count \\ 1, options \\ []) do
-    {:ok, res} = q(redis, ["LREM", list, count, value], options)
+    {:ok, res} =
+      if is_list(value) do
+        commands = Enum.map(value, fn v -> ["LREM", list, count, v] end)
+        qp(redis, commands, options)
+      else
+        q(redis, ["LREM", list, count, value], options)
+      end
+
     res
   end
 

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -394,8 +394,8 @@ defmodule Exq.Redis.JobQueue do
     Connection.zrem!(redis, retry_queue_key(namespace), job)
   end
 
-  def remove_retry_job(redis, namespace, raw_job) do
-    Connection.zrem!(redis, retry_queue_key(namespace), raw_job)
+  def remove_retry_jobs(redis, namespace, raw_jobs) do
+    Connection.zrem!(redis, retry_queue_key(namespace), raw_jobs)
   end
 
   def remove_scheduled(redis, namespace, jid) do

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -380,8 +380,8 @@ defmodule Exq.Redis.JobQueue do
     Connection.zcard!(redis, failed_queue_key(namespace))
   end
 
-  def remove_enqueued_job(redis, namespace, queue, raw_job) do
-    Connection.lrem!(redis, queue_key(namespace, queue), raw_job)
+  def remove_enqueued_jobs(redis, namespace, queue, raw_jobs) do
+    Connection.lrem!(redis, queue_key(namespace, queue), raw_jobs)
   end
 
   def remove_job(redis, namespace, queue, jid) do

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -350,7 +350,7 @@ defmodule Exq.Redis.JobQueue do
 
   def failed(redis, namespace, options \\ []) do
     if Keyword.get(options, :score, false) do
-      Connection.zrangebyscorewithscoreandlimit!(
+      Connection.zrevrangebyscorewithscoreandlimit!(
         redis,
         failed_queue_key(namespace),
         Keyword.get(options, :offset, 0),
@@ -358,7 +358,7 @@ defmodule Exq.Redis.JobQueue do
       )
       |> decode_zset_withscores(options)
     else
-      Connection.zrangebyscorewithlimit!(
+      Connection.zrevrangebyscorewithlimit!(
         redis,
         failed_queue_key(namespace),
         Keyword.get(options, :offset, 0),

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -407,6 +407,10 @@ defmodule Exq.Redis.JobQueue do
     Connection.zrem!(redis, scheduled_queue_key(namespace), raw_jobs)
   end
 
+  def remove_failed_jobs(redis, namespace, raw_jobs) do
+    Connection.zrem!(redis, failed_queue_key(namespace), raw_jobs)
+  end
+
   def list_queues(redis, namespace) do
     Connection.smembers!(redis, full_key(namespace, "queues"))
   end

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -403,6 +403,10 @@ defmodule Exq.Redis.JobQueue do
     Connection.zrem!(redis, scheduled_queue_key(namespace), job)
   end
 
+  def remove_scheduled_jobs(redis, namespace, raw_jobs) do
+    Connection.zrem!(redis, scheduled_queue_key(namespace), raw_jobs)
+  end
+
   def list_queues(redis, namespace) do
     Connection.smembers!(redis, full_key(namespace, "queues"))
   end

--- a/lib/exq/redis/job_stat.ex
+++ b/lib/exq/redis/job_stat.ex
@@ -96,6 +96,12 @@ defmodule Exq.Redis.JobStat do
     |> JobQueue.search_jobs(jid, !Keyword.get(options, :raw, false))
   end
 
+  def find_retry(redis, namespace, score, jid, options) do
+    redis
+    |> Connection.zrangebyscore!(JobQueue.full_key(namespace, "retry"), score, score)
+    |> JobQueue.search_jobs(jid, !Keyword.get(options, :raw, false))
+  end
+
   def remove_queue(redis, namespace, queue) do
     Connection.qp(redis, [
       ["SREM", JobQueue.full_key(namespace, "queues"), queue],

--- a/lib/exq/redis/job_stat.ex
+++ b/lib/exq/redis/job_stat.ex
@@ -90,6 +90,12 @@ defmodule Exq.Redis.JobStat do
     |> JobQueue.search_jobs(jid)
   end
 
+  def find_failed(redis, namespace, score, jid, options) do
+    redis
+    |> Connection.zrangebyscore!(JobQueue.full_key(namespace, "dead"), score, score)
+    |> JobQueue.search_jobs(jid, !Keyword.get(options, :raw, false))
+  end
+
   def remove_queue(redis, namespace, queue) do
     Connection.qp(redis, [
       ["SREM", JobQueue.full_key(namespace, "queues"), queue],

--- a/lib/exq/redis/job_stat.ex
+++ b/lib/exq/redis/job_stat.ex
@@ -91,15 +91,15 @@ defmodule Exq.Redis.JobStat do
   end
 
   def find_failed(redis, namespace, score, jid, options) do
-    redis
-    |> Connection.zrangebyscore!(JobQueue.full_key(namespace, "dead"), score, score)
-    |> JobQueue.search_jobs(jid, !Keyword.get(options, :raw, false))
+    find_by_score_and_jid(redis, JobQueue.full_key(namespace, "dead"), score, jid, options)
   end
 
   def find_retry(redis, namespace, score, jid, options) do
-    redis
-    |> Connection.zrangebyscore!(JobQueue.full_key(namespace, "retry"), score, score)
-    |> JobQueue.search_jobs(jid, !Keyword.get(options, :raw, false))
+    find_by_score_and_jid(redis, JobQueue.full_key(namespace, "retry"), score, jid, options)
+  end
+
+  def find_scheduled(redis, namespace, score, jid, options) do
+    find_by_score_and_jid(redis, JobQueue.full_key(namespace, "schedule"), score, jid, options)
   end
 
   def remove_queue(redis, namespace, queue) do
@@ -188,5 +188,11 @@ defmodule Exq.Redis.JobStat do
         {val, _} = Integer.parse(count)
         val
     end
+  end
+
+  defp find_by_score_and_jid(redis, zset, score, jid, options) do
+    redis
+    |> Connection.zrangebyscore!(zset, score, score)
+    |> JobQueue.search_jobs(jid, !Keyword.get(options, :raw, false))
   end
 end


### PR DESCRIPTION
* Adds pagination support
* Expose more efficient ways to fetch and delete jobs. This allows exq_ui to delete jobs or fetch jobs without doing the filtering at exq level.

Breaking Changes

* Though none of the old API is removed, some of the APIs are updated to return only the first 100 items instead of the full list. The next version of exq_ui will be updated to use pagination.