### PR TITLE
Replace deprecated Supervisor calls

### DIFF
--- a/lib/exq/support/mode.ex
+++ b/lib/exq/support/mode.ex
@@ -14,7 +14,6 @@ defmodule Exq.Support.Mode do
   """
 
   import Exq.Support.Opts, only: [redis_worker_opts: 1]
-  import Supervisor.Spec
 
   def children(opts) do
     {module, args, opts} = redis_worker_opts(opts)
@@ -68,4 +67,19 @@ defmodule Exq.Support.Mode do
   end
 
   def children([:api, :enqueuer], opts), do: children([:enqueuer, :api], opts)
+
+  defp worker(module, args, opts \\ []) do
+    overrides = Keyword.put(opts, :type, :worker)
+    supervisor_child_spec(module, args, overrides)
+  end
+
+  defp supervisor(module, args, opts \\ []) do
+    overrides = Keyword.put(opts, :type, :supervisor)
+    supervisor_child_spec(module, args, overrides)
+  end
+
+  defp supervisor_child_spec(module, args, overrides) do
+    spec = %{id: module, start: {module, :start_link, args}}
+    Supervisor.child_spec(spec, overrides)
+  end
 end

--- a/test/mode_test.exs
+++ b/test/mode_test.exs
@@ -5,10 +5,10 @@ defmodule ModeTest do
     children = Exq.Support.Mode.children(shutdown_timeout: 10_000)
 
     worker_drainer_child_spec = find_child(children, Exq.WorkerDrainer.Server)
-    assert {_id, _start, _restart, 10_000, _type, _module} = worker_drainer_child_spec
+    assert %{shutdown: 10_000} = worker_drainer_child_spec
   end
 
   defp find_child(children, child_id) do
-    Enum.find(children, fn {id, _, _, _, _, _} -> id == child_id end)
+    Enum.find(children, fn %{id: id} -> id == child_id end)
   end
 end


### PR DESCRIPTION
* Update from deprecated `Supervisor.start_child/2` with a list of args and `Supervisor.Spec.supervise/2` to `DynamicSupervisor`
* Update from deprecated `Supervisor.Spec.worker/3` to `Supervisor.child_spec/2`

### fixed compile-time warnings
```
warning: Supervisor.Spec.supervisor/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/exq/support/mode.ex:34: Exq.Support.Mode.children/2

warning: Supervisor.Spec.worker/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
Found at 13 locations:
  lib/exq/support/mode.ex:22: Exq.Support.Mode.children/1
  lib/exq/support/mode.ex:31: Exq.Support.Mode.children/2
  lib/exq/support/mode.ex:32: Exq.Support.Mode.children/2
  lib/exq/support/mode.ex:33: Exq.Support.Mode.children/2
  lib/exq/support/mode.ex:35: Exq.Support.Mode.children/2
  lib/exq/support/mode.ex:37: Exq.Support.Mode.children/2
  lib/exq/support/mode.ex:38: Exq.Support.Mode.children/2
  lib/exq/support/mode.ex:43: Exq.Support.Mode.children/2
  lib/exq/support/mode.ex:49: Exq.Support.Mode.children/2
  lib/exq/support/mode.ex:56: Exq.Support.Mode.children/2
  lib/exq/support/mode.ex:60: Exq.Support.Mode.children/2
  lib/exq/support/mode.ex:65: Exq.Support.Mode.children/2
  lib/exq/support/mode.ex:66: Exq.Support.Mode.children/2

warning: Supervisor.Spec.worker/3 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/exq/support/mode.ex:36: Exq.Support.Mode.children/2

warning: Supervisor.Spec.supervise/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/exq/worker/supervisor.ex:19: Exq.Worker.Supervisor.init/1

warning: Supervisor.Spec.worker/3 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/exq/worker/supervisor.ex:16: Exq.Worker.Supervisor.init/1
```

### fixed warnings during application start
```
warning: Supervisor.start_child/2 with a list of args is deprecated, please use DynamicSupervisor instead
  (elixir 1.12.2) lib/supervisor.ex:826: Supervisor.start_child/2
  (exq 0.15.0) lib/exq/manager/server.ex:333: Exq.Manager.Server.dispatch_job/3
  (exq 0.15.0) lib/exq/manager/server.ex:323: Exq.Manager.Server.dispatch_job/2
  (exq 0.15.0) lib/exq/manager/server.ex:273: anonymous fn/2 in Exq.Manager.Server.dequeue_and_dispatch/1
  (elixir 1.12.2) lib/enum.ex:2385: Enum."-reduce/3-lists^foldl/2-0-"/3
  (exq 0.15.0) lib/exq/manager/server.ex:272: Exq.Manager.Server.dequeue_and_dispatch/1
  (exq 0.15.0) lib/exq/manager/server.ex:237: Exq.Manager.Server.handle_info/2
  (stdlib 3.15.1) gen_server.erl:695: :gen_server.try_dispatch/4
  (stdlib 3.15.1) gen_server.erl:771: :gen_server.handle_msg/6
  (stdlib 3.15.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```

### Some explanation about shutdown_timeout
`DynamicSupervisor` does not allow specifying children supervising options during initialization as well as `Supervisor.Spec.supervise/2`. So I had to pass `shutdown_timeout` for `Exq.Worker.Server` via options in `Exq.Worker.Supervisor.start_child/3`