### PR TITLE
Sidekiq 5 UI compatibility

### DIFF
--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -53,6 +53,14 @@ defmodule Exq.Api do
   end
 
   @doc """
+  List of worker nodes currently running
+  """
+
+  def nodes(pid) do
+    GenServer.call(pid, :nodes)
+  end
+
+  @doc """
   List of processes currently running
 
   Expected args:

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -35,6 +35,11 @@ defmodule Exq.Api.Server do
     {:reply, {:ok, count}, state}
   end
 
+  def handle_call(:nodes, _from, state) do
+    nodes = JobStat.nodes(state.redis, state.namespace)
+    {:reply, {:ok, nodes}, state}
+  end
+
   def handle_call({:stats, key}, _from, state) do
     count = JobStat.get_count(state.redis, state.namespace, key)
     {:reply, {:ok, count}, state}

--- a/lib/exq/manager/server.ex
+++ b/lib/exq/manager/server.ex
@@ -420,12 +420,16 @@ defmodule Exq.Manager.Server do
     try do
       {:ok, _} = Exq.Redis.Connection.q(opts[:redis], ~w(PING))
 
-      :ok =
-        Exq.Redis.Heartbeat.register(
-          opts[:redis],
-          opts[:namespace],
-          Config.node_identifier().node_id()
-        )
+      if Keyword.get(opts, :heartbeat_enable, false) do
+        :ok =
+          Exq.Redis.Heartbeat.register(
+            opts[:redis],
+            opts[:namespace],
+            Config.node_identifier().node_id()
+          )
+      else
+        :ok
+      end
     catch
       err, reason ->
         opts = Exq.Support.Opts.redis_inspect_opts(opts)

--- a/lib/exq/middleware/stats.ex
+++ b/lib/exq/middleware/stats.ex
@@ -24,6 +24,7 @@ defmodule Exq.Middleware.Stats do
       assigns.namespace,
       worker_pid,
       assigns.host,
+      assigns.queue,
       assigns.job_serialized
     )
   end

--- a/lib/exq/node/server.ex
+++ b/lib/exq/node/server.ex
@@ -1,0 +1,94 @@
+defmodule Exq.Node.Server do
+  use GenServer
+  require Logger
+  alias Exq.Support.Config
+  alias Exq.Support.Time
+  alias Exq.Redis.JobStat
+
+  defmodule State do
+    defstruct [:info, :interval, :namespace, :redis, :node_id, :manager, :workers_sup]
+  end
+
+  def start_link(options) do
+    node_id = Keyword.get(options, :node_id, Config.node_identifier().node_id())
+
+    GenServer.start_link(
+      __MODULE__,
+      %State{
+        manager: Keyword.fetch!(options, :manager),
+        workers_sup: Keyword.fetch!(options, :workers_sup),
+        node_id: node_id,
+        info: node_info(node_id),
+        namespace: Keyword.fetch!(options, :namespace),
+        redis: Keyword.fetch!(options, :redis),
+        interval: 5000
+      },
+      []
+    )
+  end
+
+  def init(state) do
+    :ok = schedule_ping(state.interval)
+    {:ok, state}
+  end
+
+  def handle_info(
+        :ping,
+        %{
+          info: info,
+          namespace: namespace,
+          node_id: node_id,
+          redis: redis,
+          manager: manager,
+          workers_sup: workers_sup
+        } = state
+      ) do
+    {:ok, queues} = Exq.subscriptions(manager)
+    info = %{info | queues: queues}
+    busy = Exq.Worker.Supervisor.workers_count(workers_sup)
+
+    :ok =
+      JobStat.node_ping(redis, namespace, node_id, info, queues, busy)
+      |> process_signal(state)
+
+    :ok = schedule_ping(state.interval)
+    {:noreply, state}
+  end
+
+  def handle_info(msg, state) do
+    Logger.error("Received unexpected info message in #{__MODULE__} #{inspect(msg)}")
+    {:noreply, state}
+  end
+
+  defp process_signal(nil, _), do: :ok
+
+  defp process_signal("TSTP", state) do
+    Logger.info("Received TSTP, unsubscribing from all queues")
+    :ok = Exq.unsubscribe_all(state.manager)
+  end
+
+  defp process_signal(unknown, _) do
+    Logger.warn("Received unsupported signal #{unknown}")
+    :ok
+  end
+
+  defp schedule_ping(interval) do
+    _reference = Process.send_after(self(), :ping, interval)
+    :ok
+  end
+
+  defp node_info(node_id) do
+    {:ok, hostname} = :inet.gethostname()
+
+    %{
+      hostname: to_string(hostname),
+      started_at: Time.unix_seconds(),
+      pid: System.pid(),
+      tag: "",
+      concurrency: 0,
+      queues: [],
+      labels: [],
+      identity: node_id
+    }
+  end
+end

--- a/lib/exq/node/server.ex
+++ b/lib/exq/node/server.ex
@@ -83,7 +83,7 @@ defmodule Exq.Node.Server do
     %Node{
       hostname: to_string(hostname),
       started_at: Time.unix_seconds(),
-      pid: System.pid(),
+      pid: List.to_string(:os.getpid()),
       identity: node_id
     }
   end

--- a/lib/exq/redis/job_stat.ex
+++ b/lib/exq/redis/job_stat.ex
@@ -148,7 +148,12 @@ defmodule Exq.Redis.JobStat do
         end)
 
       if !Enum.empty?(dead_node_ids) do
-        Connection.q(redis, ["SREM", nodes_key(namespace)] ++ dead_node_ids)
+        commands = [
+          ["SREM", nodes_key(namespace)] ++ dead_node_ids,
+          ["DEL"] ++ Enum.map(node_ids, &workers_key(namespace, &1))
+        ]
+
+        Connection.qp(redis, commands)
       end
     end
   end

--- a/lib/exq/redis/job_stat.ex
+++ b/lib/exq/redis/job_stat.ex
@@ -44,7 +44,7 @@ defmodule Exq.Redis.JobStat do
 
   def add_process_commands(namespace, process_info, serialized_process \\ nil) do
     serialized = serialized_process || Exq.Support.Process.encode(process_info)
-    [["SADD", JobQueue.full_key(namespace, "processes"), serialized]]
+    [["HSET", workers_key(namespace, process_info.host), process_info.pid, serialized]]
   end
 
   def add_process(redis, namespace, process_info, serialized_process \\ nil) do
@@ -53,35 +53,85 @@ defmodule Exq.Redis.JobStat do
     :ok
   end
 
-  def remove_process_commands(namespace, process_info, serialized_process \\ nil) do
-    serialized = serialized_process || Exq.Support.Process.encode(process_info)
-    [["SREM", JobQueue.full_key(namespace, "processes"), serialized]]
+  def remove_process_commands(namespace, process_info) do
+    [["HDEL", workers_key(namespace, process_info.host), process_info.pid]]
   end
 
-  def remove_process(redis, namespace, process_info, serialized_process \\ nil) do
-    instr = remove_process_commands(namespace, process_info, serialized_process)
+  def remove_process(redis, namespace, process_info) do
+    instr = remove_process_commands(namespace, process_info)
     Connection.qp!(redis, instr)
     :ok
   end
 
   def cleanup_processes(redis, namespace, host) do
-    Connection.smembers!(redis, JobQueue.full_key(namespace, "processes"))
-    |> Enum.map(fn serialized -> {Process.decode(serialized), serialized} end)
-    |> Enum.filter(fn {process, _} -> process.host == host end)
-    |> Enum.each(fn {process, serialized} ->
-      remove_process(redis, namespace, process, serialized)
-    end)
-
+    Connection.del!(redis, workers_key(namespace, host))
     :ok
   end
 
+  def node_ping(redis, namespace, node_id, info, queues, busy) do
+    key = node_info_key(namespace, node_id)
+
+    case Connection.qp(
+           redis,
+           [
+             ["MULTI"],
+             ["SADD", nodes_key(namespace), node_id],
+             [
+               "HMSET",
+               key,
+               "info",
+               Exq.Serializers.JsonSerializer.encode!(info),
+               "busy",
+               busy,
+               "beat",
+               Time.unix_seconds(),
+               "quiet",
+               Enum.empty?(queues)
+             ],
+             ["EXPIRE", key, 60],
+             ["RPOP", "#{key}-signals"],
+             ["EXEC"]
+           ]
+         ) do
+      {:ok, ["OK", "QUEUED", "QUEUED", "QUEUED", "QUEUED", [_, "OK", 1, signal]]} ->
+        signal
+
+      error ->
+        Logger.error("Failed to send node stats. Unexpected error from redis: #{inspect(error)}")
+
+        nil
+    end
+  end
+
+  def nodes(redis, namespace) do
+    Connection.smembers!(redis, nodes_key(namespace))
+  end
+
   def busy(redis, namespace) do
-    Connection.scard!(redis, JobQueue.full_key(namespace, "processes"))
+    commands =
+      nodes(redis, namespace)
+      |> Enum.map(fn node_id -> ["HGET", node_info_key(namespace, node_id), "busy"] end)
+
+    if Enum.empty?(commands) do
+      0
+    else
+      Connection.qp!(redis, commands)
+      |> Enum.reduce(0, fn count, sum -> sum + decode_integer(count) end)
+    end
   end
 
   def processes(redis, namespace) do
-    list = Connection.smembers!(redis, JobQueue.full_key(namespace, "processes")) || []
-    Enum.map(list, &Process.decode/1)
+    commands =
+      nodes(redis, namespace)
+      |> Enum.map(fn node_id -> ["HVALS", workers_key(namespace, node_id)] end)
+
+    if Enum.empty?(commands) do
+      []
+    else
+      Connection.qp!(redis, commands)
+      |> List.flatten()
+      |> Enum.map(&Process.decode/1)
+    end
   end
 
   def find_failed(redis, namespace, jid) do
@@ -126,7 +176,15 @@ defmodule Exq.Redis.JobStat do
   end
 
   def clear_processes(redis, namespace) do
-    Connection.del!(redis, JobQueue.full_key(namespace, "processes"))
+    commands =
+      nodes(redis, namespace)
+      |> Enum.map(fn node_id -> ["DEL", workers_key(namespace, node_id)] end)
+
+    if Enum.empty?(commands) do
+      0
+    else
+      Connection.qp!(redis, commands)
+    end
   end
 
   def realtime_stats(redis, namespace) do
@@ -198,5 +256,17 @@ defmodule Exq.Redis.JobStat do
     redis
     |> Connection.zrangebyscore!(zset, score, score)
     |> JobQueue.search_jobs(jid, !Keyword.get(options, :raw, false))
+  end
+
+  defp workers_key(namespace, node_id) do
+    JobQueue.full_key(namespace, "#{node_id}:workers")
+  end
+
+  defp nodes_key(namespace) do
+    "#{namespace}:processes"
+  end
+
+  defp node_info_key(namespace, node_id) do
+    "#{namespace}:#{node_id}"
   end
 end

--- a/lib/exq/serializers/json_serializer.ex
+++ b/lib/exq/serializers/json_serializer.ex
@@ -68,7 +68,9 @@ defmodule Exq.Serializers.JsonSerializer do
     %Exq.Support.Process{
       pid: Map.get(deserialized, "pid"),
       host: Map.get(deserialized, "host"),
-      payload: Map.get(deserialized, "payload"),
+      payload:
+        Map.get(deserialized, "payload")
+        |> Exq.Support.Job.decode(),
       run_at: Map.get(deserialized, "run_at"),
       queue: Map.get(deserialized, "queue")
     }
@@ -88,5 +90,26 @@ defmodule Exq.Serializers.JsonSerializer do
       )
 
     encode!(deserialized)
+  end
+
+  def encode_node(node) do
+    encode!(Map.from_struct(node))
+  end
+
+  def decode_node(serialized) do
+    deserialized = decode!(serialized)
+
+    %Exq.Support.Node{
+      hostname: Map.get(deserialized, "hostname"),
+      identity: Map.get(deserialized, "identity"),
+      started_at: Map.get(deserialized, "started_at"),
+      pid: Map.get(deserialized, "pid"),
+      queues: Map.get(deserialized, "queues"),
+      labels: Map.get(deserialized, "labels"),
+      tag: Map.get(deserialized, "tag"),
+      busy: Map.get(deserialized, "busy"),
+      quiet: Map.get(deserialized, "quiet"),
+      concurrency: Map.get(deserialized, "concurrency")
+    }
   end
 end

--- a/lib/exq/serializers/json_serializer.ex
+++ b/lib/exq/serializers/json_serializer.ex
@@ -68,21 +68,21 @@ defmodule Exq.Serializers.JsonSerializer do
     %Exq.Support.Process{
       pid: Map.get(deserialized, "pid"),
       host: Map.get(deserialized, "host"),
-      job: Map.get(deserialized, "job"),
-      started_at: Map.get(deserialized, "started_at")
+      payload: Map.get(deserialized, "payload"),
+      run_at: Map.get(deserialized, "run_at"),
+      queue: Map.get(deserialized, "queue")
     }
   end
 
   def encode_process(process) do
-    formatted_pid = to_string(:io_lib.format("~p", [process.pid]))
-
     deserialized =
       Enum.into(
         [
-          pid: formatted_pid,
+          pid: process.pid,
           host: process.host,
-          job: process.job,
-          started_at: process.started_at
+          payload: process.payload,
+          run_at: process.run_at,
+          queue: process.queue
         ],
         Map.new()
       )

--- a/lib/exq/support/mode.ex
+++ b/lib/exq/support/mode.ex
@@ -30,6 +30,7 @@ defmodule Exq.Support.Mode do
       worker(Exq.Worker.Metadata, [opts]),
       worker(Exq.Middleware.Server, [opts]),
       worker(Exq.Stats.Server, [opts]),
+      worker(Exq.Node.Server, [opts]),
       supervisor(Exq.Worker.Supervisor, [opts]),
       worker(Exq.Manager.Server, [opts]),
       worker(Exq.WorkerDrainer.Server, [opts], shutdown: shutdown_timeout),

--- a/lib/exq/support/node.ex
+++ b/lib/exq/support/node.ex
@@ -1,0 +1,31 @@
+defmodule Exq.Support.Node do
+  @moduledoc """
+  Struct for node.
+  """
+  defstruct hostname: nil,
+            identity: nil,
+            started_at: nil,
+            pid: nil,
+            queues: [],
+            labels: [],
+            tag: "",
+            busy: 0,
+            concurrency: 0,
+            quiet: false
+
+  alias Exq.Support.Config
+
+  @doc """
+  Serialize node to JSON.
+  """
+  def encode(%__MODULE__{} = node) do
+    Config.serializer().encode_node(node)
+  end
+
+  @doc """
+  Decode JSON into node.
+  """
+  def decode(serialized) do
+    Config.serializer().decode_node(serialized)
+  end
+end

--- a/lib/exq/support/opts.ex
+++ b/lib/exq/support/opts.ex
@@ -119,6 +119,7 @@ defmodule Exq.Support.Opts do
     shutdown_timeout =
       Coercion.to_integer(opts[:shutdown_timeout] || Config.get(:shutdown_timeout))
 
+    manager = Exq.Manager.Server.server_name(opts[:name])
     enqueuer = Exq.Enqueuer.Server.server_name(opts[:name])
     stats = Exq.Stats.Server.server_name(opts[:name])
     scheduler = Exq.Scheduler.Server.server_name(opts[:name])
@@ -153,6 +154,7 @@ defmodule Exq.Support.Opts do
       metadata: metadata,
       stats: stats,
       name: opts[:name],
+      manager: manager,
       scheduler: scheduler,
       queues: queues,
       redis: opts[:redis],

--- a/lib/exq/support/process.ex
+++ b/lib/exq/support/process.ex
@@ -2,7 +2,7 @@ defmodule Exq.Support.Process do
   @moduledoc """
   Struct for in progress worker.
   """
-  defstruct pid: nil, host: nil, job: nil, started_at: nil
+  defstruct pid: nil, host: nil, payload: nil, run_at: nil, queue: nil
 
   alias Exq.Support.Config
 
@@ -13,8 +13,9 @@ defmodule Exq.Support.Process do
     Config.serializer().encode_process(%{
       pid: process.pid,
       host: process.host,
-      job: Exq.Support.Job.encode(process.job),
-      started_at: process.started_at
+      payload: Exq.Support.Job.encode(process.payload),
+      run_at: process.run_at,
+      queue: process.queue
     })
   end
 

--- a/lib/exq/worker/supervisor.ex
+++ b/lib/exq/worker/supervisor.ex
@@ -34,4 +34,9 @@ defmodule Exq.Worker.Supervisor do
   def workers(sup) do
     DynamicSupervisor.which_children(sup)
   end
+
+  def workers_count(sup) do
+    DynamicSupervisor.count_children(sup)
+    |> Map.get(:active)
+  end
 end

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -44,7 +44,7 @@ defmodule ApiTest do
 
   test "busy processes when processing" do
     Exq.enqueue(Exq, 'custom', Bogus, [])
-    JobStat.add_process(:testredis, "test", %Process{pid: self()})
+    JobStat.node_ping(:testredis, "test", "host1", %{}, [], 1)
     assert {:ok, 1} = Exq.Api.busy(Exq.Api)
   end
 
@@ -74,9 +74,11 @@ defmodule ApiTest do
   end
 
   test "processes with data" do
-    JobStat.add_process(:testredis, "test", %Process{pid: self()})
+    JobStat.node_ping(:testredis, "test", "host1", %{}, [], 1)
+
+    JobStat.add_process(:testredis, "test", %Process{host: "host1", pid: inspect(self())})
     assert {:ok, [processes]} = Exq.Api.processes(Exq.Api)
-    my_pid_str = to_string(:erlang.pid_to_list(self()))
+    my_pid_str = inspect(self())
     assert %Process{pid: ^my_pid_str} = processes
   end
 

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -5,6 +5,7 @@ defmodule ApiTest do
   alias Exq.Redis.JobQueue
   alias Exq.Support.Process
   alias Exq.Support.Job
+  alias Exq.Support.Node
 
   setup do
     TestRedis.setup()
@@ -38,13 +39,24 @@ defmodule ApiTest do
     assert {:ok, []} = Exq.Api.queues(Exq.Api)
   end
 
+  test "empty node list" do
+    assert {:ok, []} = Exq.Api.nodes(Exq.Api)
+  end
+
+  test "nodes when present" do
+    JobStat.node_ping(:testredis, "test", %Node{identity: "host1", busy: 1})
+    JobStat.node_ping(:testredis, "test", %Node{identity: "host2", busy: 1})
+    {:ok, nodes} = Exq.Api.nodes(Exq.Api)
+    assert ["host1", "host2"] == Enum.map(nodes, & &1.identity) |> Enum.sort()
+  end
+
   test "busy processes when empty" do
     assert {:ok, 0} = Exq.Api.busy(Exq.Api)
   end
 
   test "busy processes when processing" do
     Exq.enqueue(Exq, 'custom', Bogus, [])
-    JobStat.node_ping(:testredis, "test", "host1", %{}, [], 1)
+    JobStat.node_ping(:testredis, "test", %Node{identity: "host1", busy: 1})
     assert {:ok, 1} = Exq.Api.busy(Exq.Api)
   end
 
@@ -74,9 +86,14 @@ defmodule ApiTest do
   end
 
   test "processes with data" do
-    JobStat.node_ping(:testredis, "test", "host1", %{}, [], 1)
+    JobStat.node_ping(:testredis, "test", %Node{identity: "host1", busy: 1})
 
-    JobStat.add_process(:testredis, "test", %Process{host: "host1", pid: inspect(self())})
+    JobStat.add_process(:testredis, "test", %Process{
+      host: "host1",
+      pid: inspect(self()),
+      payload: %Job{}
+    })
+
     assert {:ok, [processes]} = Exq.Api.processes(Exq.Api)
     my_pid_str = inspect(self())
     assert %Process{pid: ^my_pid_str} = processes

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -247,6 +247,7 @@ defmodule Exq.ConfigTest do
       metadata: metadata,
       stats: stats,
       name: name,
+      manager: manager,
       scheduler: scheduler,
       queues: queues,
       redis: redis,
@@ -269,6 +270,7 @@ defmodule Exq.ConfigTest do
     assert enqueuer == Exq.Enqueuer
     assert stats == Exq.Stats
     assert name == nil
+    assert manager == Exq
     assert scheduler == Exq.Scheduler
     assert metadata == Exq.Worker.Metadata
     assert queues == ["default"]

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -1,6 +1,7 @@
 defmodule ExqTest do
   use ExUnit.Case
   alias Exq.Redis.JobQueue
+  alias Exq.Redis.JobStat
   import ExqTestUtil
 
   defmodule PerformWorker do
@@ -293,6 +294,9 @@ defmodule ExqTest do
     {:ok, sup} = Exq.start_link(name: ExqP)
     state = :sys.get_state(ExqP)
 
+    host = Exq.NodeIdentifier.HostnameIdentifier.node_id()
+    JobStat.node_ping(:testredis, "test", host, %{}, [], 1)
+
     {:ok, _} = Exq.enqueue(ExqP, "default", ExqTest.SleepWorker, [100, "finished"])
     wait_long()
 
@@ -321,6 +325,9 @@ defmodule ExqTest do
     Process.register(self(), :exqtest)
     {:ok, sup} = Exq.start_link(name: ExqP)
     state = :sys.get_state(ExqP)
+    host = Exq.NodeIdentifier.HostnameIdentifier.node_id()
+
+    JobStat.node_ping(:testredis, "test", host, %{}, [], 1)
 
     {:ok, _} = Exq.enqueue(ExqP, "default", ExqTest.SleepLastWorker, [1000, "started"])
     wait_long()
@@ -331,7 +338,6 @@ defmodule ExqTest do
     assert Enum.count(processes) == 1
 
     # Clear processes for this node
-    host = Exq.NodeIdentifier.HostnameIdentifier.node_id()
     Exq.Stats.Server.cleanup_host_stats(ExqP.Stats, "test", host)
 
     # Check that process has been cleared

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -2,6 +2,7 @@ defmodule ExqTest do
   use ExUnit.Case
   alias Exq.Redis.JobQueue
   alias Exq.Redis.JobStat
+  alias Exq.Support.Node
   import ExqTestUtil
 
   defmodule PerformWorker do
@@ -295,7 +296,7 @@ defmodule ExqTest do
     state = :sys.get_state(ExqP)
 
     host = Exq.NodeIdentifier.HostnameIdentifier.node_id()
-    JobStat.node_ping(:testredis, "test", host, %{}, [], 1)
+    JobStat.node_ping(:testredis, "test", %Node{identity: host, busy: 1})
 
     {:ok, _} = Exq.enqueue(ExqP, "default", ExqTest.SleepWorker, [100, "finished"])
     wait_long()
@@ -327,7 +328,7 @@ defmodule ExqTest do
     state = :sys.get_state(ExqP)
     host = Exq.NodeIdentifier.HostnameIdentifier.node_id()
 
-    JobStat.node_ping(:testredis, "test", host, %{}, [], 1)
+    JobStat.node_ping(:testredis, "test", %Node{identity: host, busy: 1})
 
     {:ok, _} = Exq.enqueue(ExqP, "default", ExqTest.SleepLastWorker, [1000, "started"])
     wait_long()

--- a/test/job_stat_test.exs
+++ b/test/job_stat_test.exs
@@ -7,6 +7,7 @@ defmodule JobStatTest do
   alias Exq.Support.Process
   alias Exq.Support.Job
   alias Exq.Support.Time
+  alias Exq.Support.Node
 
   defmodule EmptyMethodWorker do
     def perform do
@@ -111,7 +112,7 @@ defmodule JobStatTest do
 
   test "add and remove process" do
     namespace = "test"
-    JobStat.node_ping(:testredis, namespace, "host123", %{}, [], 1)
+    JobStat.node_ping(:testredis, "test", %Node{identity: "host123", busy: 1})
     {process_info, serialized} = create_process_info("host123")
     JobStat.add_process(:testredis, namespace, process_info, serialized)
     assert Enum.count(Exq.Redis.JobStat.processes(:testredis, namespace)) == 1
@@ -123,8 +124,8 @@ defmodule JobStatTest do
   test "remove processes on boot" do
     namespace = "test"
 
-    JobStat.node_ping(:testredis, "test", "host123", %{}, [], 1)
-    JobStat.node_ping(:testredis, "test", "host456", %{}, [], 1)
+    JobStat.node_ping(:testredis, "test", %Node{identity: "host123", busy: 1})
+    JobStat.node_ping(:testredis, "test", %Node{identity: "host456", busy: 1})
 
     # add processes for multiple hosts
     {local_process, serialized1} = create_process_info("host123")

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -87,7 +87,7 @@ defmodule WorkerTest do
       {:noreply, state}
     end
 
-    def handle_cast({:process_terminated, _, _, _}, state) do
+    def handle_cast({:process_terminated, _, _}, state) do
       send(:workertest, :process_terminated)
       {:noreply, state}
     end


### PR DESCRIPTION
Adds support for sidekiq 5 UI. Threads (aka concurrency) is set to 0 since we allow custom dequeuers which might allow jobs based on different constrain. Busy count should be accurate. The `Quiet` button would cause the node to unsubscribe from all queues.

## Code 

1. This change introduces the concept of worker nodes. The list of active worker nodes is tracked in a set `exq:processes`. For each worker node, some metadata like subscribed queues, number of busy jobs, start time etc are tracked. A new GenServer called `Exq.Node.Server` is introduced to send heartbeat and the metadata info to the redis every 5 seconds. It also cleans up the dead worker nodes' info from redis.
2. The concept of per worker signal is introduced. Currently we support `TSTP` (quiet), which will ask the worker node to unsubscribe all active queue subscription.
3. Per worker metadata is stored under `exq:{node_id}` hash and kept updated by the GenServer. This info will expire in 60 seconds (which should happen when the worker dies)
4. Per worker active jobs are stored in `exq:{node_id}:workers` hash. Each individual job will get removed once it's done. The whole hash is deleted on node startup and on dead node cleanup

## Upgrade Instructions

There are 2 types of breaking changes introduced by this PR.

1. We used to store the set of actives jobs under `exq:processes`, but the list of active worker nodes node_id is being stored now. The new version gracefully handles unknown entries (it will be cleaned up eventually by prune_dead_nodes). So upgrade should not be an issue. But the old code won't handle node_id (non json), so it can't be rolled back without first deleting the `exq:processes` set manually from redis console.
2. Some of the data structures used also got changed which will break ExqUI. Specially `Exq.Api.processes/1` will return struct with different attributes. Those who use ExqUI should plan the upgrade of both Exq and ExqUI. The next release of ExqUI will be compatible with the new struct.


screenshot from single node
![image](https://user-images.githubusercontent.com/149238/137460691-1b6eb06b-9083-431b-837d-0a7d91b6bbef.png)

screenshot from multiple nodes (using custom identifier functionality)
![image](https://user-images.githubusercontent.com/149238/137461384-1ac7cb07-e3cf-4daf-885d-e5d1242fec80.png)

fixes #439 #289 #288