### PR TITLE
Update README: use latest Phoenix child spec style

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,14 +198,15 @@ config :exq,
 ```
 
 ```elixir
-# Define workers and child supervisors to be supervised
-children = [
-  # Start the Ecto repository
-  supervisor(MyApp.Repo, []),
-  # Start the endpoint when the application starts
-  supervisor(MyApp.Endpoint, []),
-  supervisor(Exq, []),
-]
+def start(_type, _args) do
+  children = [
+    # Start the Ecto repository
+    MyApp.Repo,
+    # Start the endpoint when the application starts
+    MyApp.Endpoint,
+    # Start the EXQ supervisor
+    Exq,
+  ]
 ```
 
 ### Sentinel

--- a/lib/exq.ex
+++ b/lib/exq.ex
@@ -9,6 +9,14 @@ defmodule Exq do
   # Mixin Enqueue API
   use Exq.Enqueuer.EnqueueApi
 
+  def child_spec(exq_options \\ []) do
+    %{
+      id: __MODULE__,
+      type: :supervisor,
+      start: {__MODULE__, :start_link, [exq_options]}
+    }
+  end
+
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do


### PR DESCRIPTION
This is related to https://github.com/akira/exq/issues/387 and is a logical continuation of https://github.com/akira/exq/pull/453/files

The current PR adds `def child_spec` to `Exq` and removes `supervisor` calls from `application.ex` to match the latest version of Phoenix.

Tested with Elixir 1.7 and Elixir 1.11 (couldn't start on Elixir 1.6 because of `:telemetry` dependency)