### PR TITLE
maint: fix @doc refined warnings.

### DIFF
--- a/lib/exq/worker/server.ex
+++ b/lib/exq/worker/server.ex
@@ -104,9 +104,7 @@ defmodule Exq.Worker.Server do
     {:noreply, state}
   end
 
-  @doc """
-  Dispatch work to the target module (call :perform method of target).
-  """
+  # Dispatch work to the target module (call :perform method of target).
   def handle_cast(:dispatch, state) do
     dispatch_work(
       state.pipeline.assigns.worker_module,
@@ -117,9 +115,7 @@ defmodule Exq.Worker.Server do
     {:noreply, state}
   end
 
-  @doc """
-  Worker done with normal termination message.
-  """
+  # Worker done with normal termination message.
   def handle_cast({:done, result}, state) do
     state =
       if !has_pipeline_after_work_ran?(state.pipeline) do


### PR DESCRIPTION
Fixes compile time @doc redefined warnings. Ref. https://github.com/elixir-lang/elixir/issues/7817

```
Compiling 53 files (.ex)
warning: redefining @doc attribute previously set at line 19.

Please remove the duplicate docs. If instead you want to override a previously defined @doc, attach the @doc attribute to a function head (the function signature not followed by any do-block). For example:

    @doc """
    new docs
    """
    def handle_cast(...)

  lib/exq/worker/server.ex:107: Exq.Worker.Server.handle_cast/2

warning: redefining @doc attribute previously set at line 19.

Please remove the duplicate docs. If instead you want to override a previously defined @doc, attach the @doc attribute to a function head (the function signature not followed by any do-block). For example:

    @doc """
    new docs
    """
    def handle_cast(...)

  lib/exq/worker/server.ex:120: Exq.Worker.Server.handle_cast/2
```