### PR TITLE
Fix namespaced keys in scripts for ACL redis

### DIFF
--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -35,7 +35,7 @@ defmodule Exq.Redis.JobQueue do
     try do
       [unlocks_in, unique_key] = unique_args(namespace, job, options)
 
-      keys = [full_key(namespace, "queues"), queue_key(namespace, queue)] ++ (unique_key || [])
+      keys = keys_list([full_key(namespace, "queues"), queue_key(namespace, queue)], unique_key)
 
       response =
         Script.eval!(
@@ -98,7 +98,7 @@ defmodule Exq.Redis.JobQueue do
     try do
       [unlocks_in, unique_key] = unique_args(namespace, job, options)
 
-      keys = [scheduled_queue] ++ (unique_key || [])
+      keys = keys_list([scheduled_queue], unique_key)
 
       response =
         Script.eval!(redis, :enqueue_at, keys, [
@@ -222,6 +222,9 @@ defmodule Exq.Redis.JobQueue do
         0
     end
   end
+
+  defp keys_list([_hd | _tl] = keys, nil), do: keys
+  defp keys_list([_hd | _tl] = keys, key), do: keys ++ [key]
 
   def full_key("", key), do: key
   def full_key(nil, key), do: key

--- a/lib/exq/redis/script.ex
+++ b/lib/exq/redis/script.ex
@@ -14,8 +14,8 @@ defmodule Exq.Redis.Script do
   @scripts %{
     enqueue:
       Prepare.script("""
-      local job_queue, namespace_prefix, unique_key = KEYS[1], KEYS[2], KEYS[3]
-      local job, jid, unlocks_in = ARGV[1], ARGV[2], tonumber(ARGV[3])
+      local queues_key, job_queue_key, unique_key = KEYS[1], KEYS[2], KEYS[3]
+      local job_queue, job, jid, unlocks_in = ARGV[1], ARGV[2], ARGV[3], tonumber(ARGV[4])
       local unlocked = true
       local conflict_jid = nil
 
@@ -24,8 +24,8 @@ defmodule Exq.Redis.Script do
       end
 
       if unlocked then
-        redis.call('SADD', namespace_prefix .. 'queues', job_queue)
-        redis.call('LPUSH', namespace_prefix .. 'queue:' .. job_queue, job)
+        redis.call('SADD', queues_key, job_queue)
+        redis.call('LPUSH', job_queue_key, job)
         return 0
       else
         conflict_jid = redis.call("get", unique_key)


### PR DESCRIPTION
### Issue Details

It appears that when using the `EVAL` command redis checks all input keys against the ACL even if those keys are not used at all in the script. This makes the current version (`v0.17.0`) of `exq` raise a permission error in ACL protected redis clusters when enqueue is called since the library passes some non namespaced values as keys (including the possibly `nil` `unique_key`).

Below you can find some examples of this behaviour tested directly in an ACL protected `redis-cli`. 
The examples assume that a `namespace:` namespace is valid while `foo:` is not.

Passing a non namespaced, non used, key:

```
host:6379> EVAL "return ARGV[1]" 1 namespace: test
"test"
host:6379> EVAL "return ARGV[1]" 1 foo: test
(error) NOPERM this user has no permissions to access one of the keys used as arguments
```
Passing a nil value:

```
host:6379> EVAL "return ARGV[1]" 1 nil test
(error) NOPERM this user has no permissions to access one of the keys used as arguments
```
Passing a (not) namespaced but using a computed key.

```
host:6379> EVAL "return redis.call('SET', 'namespace:' .. 'queues', ARGV[1])" 1 foo test
(error) NOPERM this user has no permissions to access one of the keys used as arguments
host:6379> EVAL "return redis.call('SET', 'namespace:' .. 'queues', ARGV[1])" 1 namespace: test
OK
```

Citing this last example in relation to this disclaimer in the [docs](https://redis.io/docs/manual/programmability/eval-intro/):

> Important: to ensure the correct execution of scripts, both in standalone and clustered deployments, all names of keys that a script accesses must be explicitly provided as input key arguments. The script should only access keys whose names are given as input arguments. Scripts should never access keys with programmatically-generated names or based on the contents of data structures stored in the database.

### PR contribution
This pr aims to fix this refactoring how keys passed into the scripts, and avoiding passing `nil` keys to `Script.eval!/4`.
