### PR TITLE
Add enqueue_all for enqueuing a batch of jobs atomically

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,35 @@ feature depends on `Exq.Middleware.Unique` middleware. If you override
 `:middleware` configuration, make sure to include it.
 
 
+## Enqueuing Many Jobs Atomically
+
+Similar to database transactions, there are cases where you may want to
+enqueue/schedule many jobs atomically. A common usecase of this would be when you
+have a computationally heavy job and you want to break it down to multiple smaller jobs so they
+can be run concurrently. If you use a loop to enqueue/schedule these jobs,
+and a network, connectivity, or application error occurs while passing these jobs to Exq,
+you will end up in a situation where you have to roll back all the jobs that you may already
+have scheduled/enqueued which will be a complicated process. In order to avoid this problem,
+Exq comes with an `enqueue_all` method which guarantees atomicity.
+
+
+```elixir
+[{:ok, jid_1}, {:ok, jid_2}, {:ok, jid_3}] = Exq.enqueue_all(Exq, [
+  [job_1_queue, job_1_worker, job_1_args, job_1_options],
+  [job_2_queue, job_2_worker, job_2_args, job_2_options],
+  [job_3_queue, job_3_worker, job_3_args, job_3_options]
+])
+```
+
+`enqueue_all` also supports scheduling jobs via `schedule` key in the `options` passed for each job:
+```elixir
+[{:ok, jid_1}, {:ok, jid_2}, {:ok, jid_3}] = Exq.enqueue_all(Exq, [
+  [job_1_queue, job_1_worker, job_1_args, [schedule: {:in, 60 * 60}]],
+  [job_2_queue, job_2_worker, job_2_args, [schedule: {:at, midnight}]],
+  [job_3_queue, job_3_worker, job_3_args, []] # no schedule key is present, it is enqueued immediately
+])
+```
+
 ## Web UI
 
 Exq has a separate repo, exq_ui which provides with a Web UI to monitor your workers:

--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ Exq comes with an `enqueue_all` method which guarantees atomicity.
 
 
 ```elixir
-[{:ok, jid_1}, {:ok, jid_2}, {:ok, jid_3}] = Exq.enqueue_all(Exq, [
+{:ok, [{:ok, jid_1}, {:ok, jid_2}, {:ok, jid_3}]} = Exq.enqueue_all(Exq, [
   [job_1_queue, job_1_worker, job_1_args, job_1_options],
   [job_2_queue, job_2_worker, job_2_args, job_2_options],
   [job_3_queue, job_3_worker, job_3_args, job_3_options]
@@ -549,7 +549,7 @@ Exq comes with an `enqueue_all` method which guarantees atomicity.
 
 `enqueue_all` also supports scheduling jobs via `schedule` key in the `options` passed for each job:
 ```elixir
-[{:ok, jid_1}, {:ok, jid_2}, {:ok, jid_3}] = Exq.enqueue_all(Exq, [
+{:ok, [{:ok, jid_1}, {:ok, jid_2}, {:ok, jid_3}]} = Exq.enqueue_all(Exq, [
   [job_1_queue, job_1_worker, job_1_args, [schedule: {:in, 60 * 60}]],
   [job_2_queue, job_2_worker, job_2_args, [schedule: {:at, midnight}]],
   [job_3_queue, job_3_worker, job_3_args, []] # no schedule key is present, it is enqueued immediately

--- a/lib/exq/adapters/queue.ex
+++ b/lib/exq/adapters/queue.ex
@@ -30,4 +30,5 @@ defmodule Exq.Adapters.Queue do
   @callback enqueue(server, String.t(), module(), list(), list()) :: tuple()
   @callback enqueue_at(server, String.t(), DateTime.t(), module(), list(), list()) :: tuple()
   @callback enqueue_in(server, String.t(), integer(), module(), list(), list()) :: tuple()
+  @callback enqueue_all(server, list()) :: tuple()
 end

--- a/lib/exq/adapters/queue/mock.ex
+++ b/lib/exq/adapters/queue/mock.ex
@@ -12,4 +12,6 @@ defmodule Exq.Adapters.Queue.Mock do
   defdelegate enqueue_at(pid, queue, time, worker, args, options), to: Exq.Mock
 
   defdelegate enqueue_in(pid, queue, offset, worker, args, options), to: Exq.Mock
+
+  defdelegate enqueue_all(pid, jobs), to: Exq.Mock
 end

--- a/lib/exq/adapters/queue/redis.ex
+++ b/lib/exq/adapters/queue/redis.ex
@@ -23,4 +23,9 @@ defmodule Exq.Adapters.Queue.Redis do
     {redis, namespace} = GenServer.call(pid, :redis, Config.get(:genserver_timeout))
     JobQueue.enqueue_in(redis, namespace, queue, offset, worker, args, options)
   end
+
+  def enqueue_all(pid, jobs) do
+    {redis, namespace} = GenServer.call(pid, :redis, Config.get(:genserver_timeout))
+    JobQueue.enqueue_all(redis, namespace, jobs)
+  end
 end

--- a/lib/exq/enqueue_api.ex
+++ b/lib/exq/enqueue_api.ex
@@ -98,6 +98,20 @@ defmodule Exq.Enqueuer.EnqueueApi do
         queue_adapter = Config.get(:queue_adapter)
         queue_adapter.enqueue_in(pid, queue, offset, worker, args, options)
       end
+
+      @doc """
+      Schedule multiple jobs to be atomically enqueued at specific times
+
+      Expected args:
+      * `pid` - PID for Exq Manager or Enqueuer to handle this
+      * `jobs` - List of jobs
+      #{@options_doc}
+
+      """
+      def enqueue_all(pid, jobs) do
+        queue_adapter = Config.get(:queue_adapter)
+        queue_adapter.enqueue_all(pid, jobs)
+      end
     end
   end
 end

--- a/lib/exq/enqueue_api.ex
+++ b/lib/exq/enqueue_api.ex
@@ -103,9 +103,23 @@ defmodule Exq.Enqueuer.EnqueueApi do
       Schedule multiple jobs to be atomically enqueued at specific times
 
       Expected args:
-      * `pid` - PID for Exq Manager or Enqueuer to handle this
-      * `jobs` - List of jobs
-      #{@options_doc}
+        * `pid` - PID for Exq Manager or Enqueuer to handle this
+        * `jobs` - List of jobs each defined as `[queue, worker, args, options]`
+          * `queue` - Name of queue to use
+          * `worker` - Worker module to target
+          * `args` - Array of args to send to worker
+          * `options`: Following job options are supported
+            * `max_retries` (integer) - max retry count
+            * `jid` (string) - user supplied jid value
+            * `unique_for` (integer) - lock expiration duration in seconds
+            * `unique_token` (string) - unique lock token. By default the token is computed based on the queue, class and args.
+            * `unique_until` (atom) - defaults to `:success`. Supported values are
+              * `:success` - unlock on job success
+              * `:start` - unlock on job first execution
+              * `:expiry` - unlock when the lock is expired. Depends on `unique_for` value.
+            * `schedule` - (optional) - used to schedule the job for future. If not present, job will be enqueued immediately by default.
+              * `{:in, seconds_from_now}`
+              * `{:at, datetime}`
 
       """
       def enqueue_all(pid, jobs) do

--- a/lib/exq/mock.ex
+++ b/lib/exq/mock.ex
@@ -99,14 +99,14 @@ defmodule Exq.Mock do
   end
 
   def enqueue_all(pid, jobs) do
-    {:ok, runnable} =
-      GenServer.call(
-        __MODULE__,
-        {:enqueue, self(), :enqueue_all, [pid, jobs]},
-        @timeout
-      )
-
-    runnable.()
+    jobs
+    |> Enum.map(fn ([ queue, worker, args, options ]) ->
+        case options[:schedule] do
+          {:at, at_time} -> enqueue_at(pid, queue, at_time, worker, args, options)
+          {:in, offset} -> enqueue_in(pid, queue, offset, worker, args, options)
+          _ -> enqueue(pid, queue, worker, args, options)
+        end
+      end)
   end
 
   @impl true

--- a/lib/exq/mock.ex
+++ b/lib/exq/mock.ex
@@ -100,13 +100,13 @@ defmodule Exq.Mock do
 
   def enqueue_all(pid, jobs) do
     jobs
-    |> Enum.map(fn ([ queue, worker, args, options ]) ->
-        case options[:schedule] do
-          {:at, at_time} -> enqueue_at(pid, queue, at_time, worker, args, options)
-          {:in, offset} -> enqueue_in(pid, queue, offset, worker, args, options)
-          _ -> enqueue(pid, queue, worker, args, options)
-        end
-      end)
+    |> Enum.map(fn [queue, worker, args, options] ->
+      case options[:schedule] do
+        {:at, at_time} -> enqueue_at(pid, queue, at_time, worker, args, options)
+        {:in, offset} -> enqueue_in(pid, queue, offset, worker, args, options)
+        _ -> enqueue(pid, queue, worker, args, options)
+      end
+    end)
   end
 
   @impl true

--- a/lib/exq/mock.ex
+++ b/lib/exq/mock.ex
@@ -99,14 +99,16 @@ defmodule Exq.Mock do
   end
 
   def enqueue_all(pid, jobs) do
-    jobs
-    |> Enum.map(fn [queue, worker, args, options] ->
-      case options[:schedule] do
-        {:at, at_time} -> enqueue_at(pid, queue, at_time, worker, args, options)
-        {:in, offset} -> enqueue_in(pid, queue, offset, worker, args, options)
-        _ -> enqueue(pid, queue, worker, args, options)
-      end
-    end)
+    {
+      :ok,
+      Enum.map(jobs, fn [queue, worker, args, options] ->
+        case options[:schedule] do
+          {:at, at_time} -> enqueue_at(pid, queue, at_time, worker, args, options)
+          {:in, offset} -> enqueue_in(pid, queue, offset, worker, args, options)
+          _ -> enqueue(pid, queue, worker, args, options)
+        end
+      end)
+    }
   end
 
   @impl true

--- a/lib/exq/mock.ex
+++ b/lib/exq/mock.ex
@@ -98,47 +98,55 @@ defmodule Exq.Mock do
     runnable.()
   end
 
+  @doc false
   def enqueue_all(pid, jobs) do
-    {
-      :ok,
-      Enum.map(jobs, fn [queue, worker, args, options] ->
-        case options[:schedule] do
-          {:at, at_time} -> enqueue_at(pid, queue, at_time, worker, args, options)
-          {:in, offset} -> enqueue_in(pid, queue, offset, worker, args, options)
-          _ -> enqueue(pid, queue, worker, args, options)
-        end
-      end)
-    }
+    {:ok, runnable} = GenServer.call(__MODULE__, {:enqueue_all, self(), pid, jobs}, @timeout)
+    runnable.()
   end
 
   @impl true
   def handle_call({:enqueue, owner_pid, type, args}, _from, state) do
     state = maybe_add_and_monitor_pid(state, owner_pid, state.default_mode)
+    {state, runnable} = to_runnable(owner_pid, type, args, state)
+    {:reply, {:ok, runnable}, state}
+  end
 
-    case state.modes[owner_pid] do
-      :redis ->
-        runnable = fn -> apply(Redis, type, args) end
-        {:reply, {:ok, runnable}, state}
+  @impl true
+  def handle_call({:enqueue_all, owner_pid, pid, jobs}, _from, state) do
+    state = maybe_add_and_monitor_pid(state, owner_pid, state.default_mode)
 
-      :inline ->
+    {state, runnable} =
+      if state.modes[owner_pid] == :redis do
+        to_runnable(owner_pid, :enqueue_all, [pid, jobs], state)
+      else
+        {state, runnables} =
+          Enum.reduce(jobs, {state, []}, fn [queue, worker, args, options], {state, runnables} ->
+            {type, args} =
+              case options[:schedule] do
+                {:at, at_time} ->
+                  {:enqueue_at, [pid, queue, at_time, worker, args, options]}
+
+                {:in, offset} ->
+                  {:enqueue_in, [pid, queue, offset, worker, args, options]}
+
+                _ ->
+                  {:enqueue, [pid, queue, worker, args, options]}
+              end
+
+            {state, runnable} = to_runnable(owner_pid, type, args, state)
+            {state, [runnable | runnables]}
+          end)
+
+        runnables = Enum.reverse(runnables)
+
         runnable = fn ->
-          job = to_job(type, args)
-          apply(Coercion.to_module(job.class), :perform, job.args)
-          {:ok, job.jid}
+          {:ok, Enum.map(runnables, fn f -> f.() end)}
         end
 
-        {:reply, {:ok, runnable}, state}
+        {state, runnable}
+      end
 
-      :fake ->
-        job = to_job(type, args)
-        state = update_in(state.jobs[owner_pid], &((&1 || []) ++ [job]))
-
-        runnable = fn ->
-          {:ok, job.jid}
-        end
-
-        {:reply, {:ok, runnable}, state}
-    end
+    {:reply, {:ok, runnable}, state}
   end
 
   def handle_call({:mode, owner_pid, mode}, _from, state) do
@@ -156,6 +164,33 @@ defmodule Exq.Mock do
     {_, state} = pop_in(state.modes[pid])
     {_, state} = pop_in(state.jobs[pid])
     {:noreply, state}
+  end
+
+  defp to_runnable(owner_pid, type, args, state) do
+    case state.modes[owner_pid] do
+      :redis ->
+        runnable = fn -> apply(Redis, type, args) end
+        {state, runnable}
+
+      :inline ->
+        runnable = fn ->
+          job = to_job(type, args)
+          apply(Coercion.to_module(job.class), :perform, job.args)
+          {:ok, job.jid}
+        end
+
+        {state, runnable}
+
+      :fake ->
+        job = to_job(type, args)
+        state = update_in(state.jobs[owner_pid], &((&1 || []) ++ [job]))
+
+        runnable = fn ->
+          {:ok, job.jid}
+        end
+
+        {state, runnable}
+    end
   end
 
   defp to_job(_, [_pid, queue, worker, args, options]) do

--- a/lib/exq/mock.ex
+++ b/lib/exq/mock.ex
@@ -98,6 +98,17 @@ defmodule Exq.Mock do
     runnable.()
   end
 
+  def enqueue_all(pid, jobs) do
+    {:ok, runnable} =
+      GenServer.call(
+        __MODULE__,
+        {:enqueue, self(), :enqueue_all, [pid, jobs]},
+        @timeout
+      )
+
+    runnable.()
+  end
+
   @impl true
   def handle_call({:enqueue, owner_pid, type, args}, _from, state) do
     state = maybe_add_and_monitor_pid(state, owner_pid, state.default_mode)

--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -222,17 +222,6 @@ defmodule Exq.Redis.Connection do
     )
   end
 
-  def q_transaction_pipeline(redis, commands, options \\ []) do
-    Redis.with_retry_on_connection_error(
-      fn ->
-        redis
-        |> Redix.transaction_pipeline(commands, timeout: Config.get(:redis_timeout))
-        |> handle_responses(redis)
-      end,
-      Keyword.get(options, :retry_on_connection_error, 0)
-    )
-  end
-
   defp handle_response({:error, %{message: "READONLY" <> _rest}} = error, redis) do
     disconnect(redis)
     error

--- a/lib/exq/redis/connection.ex
+++ b/lib/exq/redis/connection.ex
@@ -222,6 +222,17 @@ defmodule Exq.Redis.Connection do
     )
   end
 
+  def q_transaction_pipeline(redis, commands, options \\ []) do
+    Redis.with_retry_on_connection_error(
+      fn ->
+        redis
+        |> Redix.transaction_pipeline(commands, timeout: Config.get(:redis_timeout))
+        |> handle_responses(redis)
+      end,
+      Keyword.get(options, :retry_on_connection_error, 0)
+    )
+  end
+
   defp handle_response({:error, %{message: "READONLY" <> _rest}} = error, redis) do
     disconnect(redis)
     error

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -121,23 +121,26 @@ defmodule Exq.Redis.JobQueue do
   end
 
   def enqueue_all(redis, namespace, jobs) do
-    { unique_keys, args } = extract_enqueue_all_keys_and_args(namespace, jobs)
+    {keys, args} = extract_enqueue_all_keys_and_args(namespace, jobs)
 
     Script.eval!(
       redis,
       :enqueue_all,
-      [ scheduled_queue_key(namespace) | unique_keys ],
+      [scheduled_queue_key(namespace), full_key(namespace, "queues")] ++ keys,
       args
     )
     |> case do
       {:ok, result} ->
-        result |> Enum.map(fn([status, jid]) ->
+        result
+        |> Enum.map(fn [status, jid] ->
           case status do
             0 -> {:ok, jid}
             1 -> {:conflict, jid}
           end
         end)
-      error -> error
+
+      error ->
+        error
     end
   end
 
@@ -653,26 +656,49 @@ defmodule Exq.Redis.JobQueue do
     end
   end
 
-
-
+  # Returns
+  # {
+  #   [
+  #     job_1_unique_key, job_1_queue_key,
+  #     job_2_unique_key, job_2_queue_key,
+  #     ...
+  #   ],
+  #   [
+  #     job_1_jid, job_1_queue, job_1_score, job_1_job_serialized, job_1_unlocks_in,
+  #     job_2_jid, job_2_queue, job_2_score, job_2_job_serialized, job_2_unlocks_in,
+  #     ...
+  #   ]
+  # }
   defp extract_enqueue_all_keys_and_args(namespace, jobs) do
-    { unique_keys, job_attrs} = Enum.reduce(jobs, {[], []}, fn (job, { unique_keys_acc, job_attrs_acc }) ->
-      [queue, time, worker, args, options] = job
+    {keys, job_attrs} =
+      Enum.reduce(jobs, {[], []}, fn job, {keys_acc, job_attrs_acc} ->
+        [queue, worker, args, options] = job
 
-      { jid, job_data, job_serialized } =
-        to_job_serialized(queue, worker, args, options, Time.unix_seconds(time))
+        {score, enqueued_at} =
+          case options[:schedule] do
+            {:at, at_time} ->
+              {Time.time_to_score(at_time), Time.unix_seconds(at_time)}
 
-      score = Time.time_to_score(time)
+            {:in, offset} ->
+              at_time = Time.offset_from_now(offset)
+              {Time.time_to_score(at_time), Time.unix_seconds(at_time)}
 
-      [unlocks_in, unique_key] = unique_args(namespace, job_data, unique_check: true)
+            _ ->
+              {"0", Time.unix_seconds()}
+          end
 
-      # accumulating in reverse order for efficiency
-      {
-        [ unique_key | unique_keys_acc ],
-        [ unlocks_in, job_serialized, score, jid ] ++ job_attrs_acc
-      }
-    end)
+        {jid, job_data, job_serialized} =
+          to_job_serialized(queue, worker, args, options, enqueued_at)
 
-    { Enum.reverse(unique_keys), Enum.reverse(job_attrs) }
+        [unlocks_in, unique_key] = unique_args(namespace, job_data, unique_check: true)
+
+        # accumulating in reverse order for efficiency
+        {
+          [queue_key(namespace, queue), unique_key] ++ keys_acc,
+          [unlocks_in, job_serialized, score, queue, jid] ++ job_attrs_acc
+        }
+      end)
+
+    {Enum.reverse(keys), Enum.reverse(job_attrs)}
   end
 end

--- a/lib/exq/redis/script.ex
+++ b/lib/exq/redis/script.ex
@@ -53,16 +53,19 @@ defmodule Exq.Redis.Script do
       """),
     enqueue_all:
       Prepare.script("""
-      local schedule_queue = KEYS[1]
+      local schedule_queue, queues_key = KEYS[1], KEYS[2]
       local i = 1
       local result = {}
 
-      while i < #(KEYS) do
-        local unique_key = KEYS[i + 1]
-        local jid        = ARGV[(i - 1) * 4 + 1]
-        local score      = tonumber(ARGV[(i - 1) * 4 + 2])
-        local job        = ARGV[(i - 1) * 4 + 3]
-        local unlocks_in = tonumber(ARGV[(i - 1) * 4 + 4])
+      while i <= #(ARGV) / 5 do
+        local keys_start = i * 2
+        local args_start = (i - 1) * 5
+        local unique_key, job_queue_key = KEYS[keys_start + 1], KEYS[keys_start + 2]
+        local jid        = ARGV[args_start + 1]
+        local job_queue  = ARGV[args_start + 2]
+        local score      = tonumber(ARGV[args_start + 3])
+        local job        = ARGV[args_start + 4]
+        local unlocks_in = tonumber(ARGV[args_start + 5])
         local unlocked   = true
         local conflict_jid = nil
 
@@ -70,7 +73,11 @@ defmodule Exq.Redis.Script do
           unlocked = redis.call("set", unique_key, jid, "px", unlocks_in, "nx")
         end
 
-        if unlocked then
+        if unlocked and score == 0 then
+          redis.call('SADD', queues_key, job_queue)
+          redis.call('LPUSH', job_queue_key, job)
+          result[i] = {0, jid}
+        elseif unlocked then
           redis.call('ZADD', schedule_queue, score, job)
           result[i] = {0, jid}
         else

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -141,7 +141,6 @@ defmodule ExqTest do
   test "enqueue_all and run many jobs" do
     Process.register(self(), :exqtest)
     {:ok, sup} = Exq.start_link(scheduler_enable: true)
-    {:ok, _} = Exq.enqueue_at(Exq, "default", DateTime.utc_now(), ExqTest.PerformWorker, [])
 
     {:ok, [{:ok, _}, {:ok, _}, {:ok, _}]} =
       Exq.enqueue_all(Exq, [

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -143,7 +143,7 @@ defmodule ExqTest do
     {:ok, sup} = Exq.start_link(scheduler_enable: true)
     {:ok, _} = Exq.enqueue_at(Exq, "default", DateTime.utc_now(), ExqTest.PerformWorker, [])
 
-    [{:ok, _}, {:ok, _}, {:ok, _}] =
+    {:ok, [{:ok, _}, {:ok, _}, {:ok, _}]} =
       Exq.enqueue_all(Exq, [
         ["default", ExqTest.PerformArgWorker, [1], []],
         ["default", ExqTest.PerformArgWorker, [2], [schedule: {:at, DateTime.utc_now()}]],
@@ -746,7 +746,7 @@ defmodule ExqTest do
     Process.register(self(), :exqtest)
     {:ok, sup} = Exq.start_link(concurrency: 1, queues: ["q1"], scheduler_enable: true)
 
-    [{:ok, j1}, {:conflict, j2}] =
+    {:ok, [{:ok, j1}, {:conflict, j2}]} =
       Exq.enqueue_all(Exq, [
         ["q1", PerformWorker, [], [schedule: {:in, 1}, unique_for: 60]],
         ["q1", PerformWorker, [], [schedule: {:in, 1}, unique_for: 60]]
@@ -757,7 +757,7 @@ defmodule ExqTest do
     :timer.sleep(2000)
     assert_received {:worked}
 
-    [{:ok, _}] =
+    {:ok, [{:ok, _}]} =
       Exq.enqueue_all(Exq, [
         ["q1", PerformWorker, [], [schedule: {:in, 1}, unique_for: 60]]
       ])

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -138,6 +138,21 @@ defmodule ExqTest do
     stop_process(sup)
   end
 
+  test "enqueue_all and run many jobs" do
+    Process.register(self(), :exqtest)
+    {:ok, sup} = Exq.start_link(scheduler_enable: true)
+    {:ok, _} = Exq.enqueue_at(Exq, "default", DateTime.utc_now(), ExqTest.PerformWorker, [])
+    [{:ok, _}, {:ok, _}, {:ok, _}] = Exq.enqueue_all(Exq, [
+      ["default", ExqTest.PerformArgWorker, [1], []],
+      ["default", ExqTest.PerformArgWorker, [2], [schedule: {:at, DateTime.utc_now()}]],
+      ["default", ExqTest.PerformArgWorker, [3], [schedule: {:in, 0}]]
+    ])
+    assert_receive {:worked, 1}
+    assert_receive {:worked, 2}
+    assert_receive {:worked, 3}
+    stop_process(sup)
+  end
+
   test "enqueue with separate enqueuer" do
     Process.register(self(), :exqtest)
     {:ok, exq_sup} = Exq.start_link()
@@ -720,6 +735,27 @@ defmodule ExqTest do
 
     {:ok, _} = Exq.enqueue_at(Exq, "q1", DateTime.utc_now(), PerformWorker, [], unique_for: 60)
     :timer.sleep(1000)
+    assert_received {:worked}
+    stop_process(sup)
+  end
+
+  test "prevent duplicate scheduled job while using enqueue_all" do
+    Process.register(self(), :exqtest)
+    {:ok, sup} = Exq.start_link(concurrency: 1, queues: ["q1"], scheduler_enable: true)
+    [{:ok, j1}, {:conflict, j2}] = Exq.enqueue_all(Exq, [
+      ["q1", PerformWorker, [], [schedule: {:in, 1}, unique_for: 60]],
+      ["q1", PerformWorker, [], [schedule: {:in, 1}, unique_for: 60]],
+    ])
+
+    assert j1 == j2
+
+    :timer.sleep(2000)
+    assert_received {:worked}
+
+    [{:ok, _}] = Exq.enqueue_all(Exq, [
+      ["q1", PerformWorker, [], [schedule: {:in, 1}, unique_for: 60]]
+    ])
+    :timer.sleep(1500)
     assert_received {:worked}
     stop_process(sup)
   end

--- a/test/exq_test.exs
+++ b/test/exq_test.exs
@@ -142,11 +142,14 @@ defmodule ExqTest do
     Process.register(self(), :exqtest)
     {:ok, sup} = Exq.start_link(scheduler_enable: true)
     {:ok, _} = Exq.enqueue_at(Exq, "default", DateTime.utc_now(), ExqTest.PerformWorker, [])
-    [{:ok, _}, {:ok, _}, {:ok, _}] = Exq.enqueue_all(Exq, [
-      ["default", ExqTest.PerformArgWorker, [1], []],
-      ["default", ExqTest.PerformArgWorker, [2], [schedule: {:at, DateTime.utc_now()}]],
-      ["default", ExqTest.PerformArgWorker, [3], [schedule: {:in, 0}]]
-    ])
+
+    [{:ok, _}, {:ok, _}, {:ok, _}] =
+      Exq.enqueue_all(Exq, [
+        ["default", ExqTest.PerformArgWorker, [1], []],
+        ["default", ExqTest.PerformArgWorker, [2], [schedule: {:at, DateTime.utc_now()}]],
+        ["default", ExqTest.PerformArgWorker, [3], [schedule: {:in, 0}]]
+      ])
+
     assert_receive {:worked, 1}
     assert_receive {:worked, 2}
     assert_receive {:worked, 3}
@@ -742,19 +745,23 @@ defmodule ExqTest do
   test "prevent duplicate scheduled job while using enqueue_all" do
     Process.register(self(), :exqtest)
     {:ok, sup} = Exq.start_link(concurrency: 1, queues: ["q1"], scheduler_enable: true)
-    [{:ok, j1}, {:conflict, j2}] = Exq.enqueue_all(Exq, [
-      ["q1", PerformWorker, [], [schedule: {:in, 1}, unique_for: 60]],
-      ["q1", PerformWorker, [], [schedule: {:in, 1}, unique_for: 60]],
-    ])
+
+    [{:ok, j1}, {:conflict, j2}] =
+      Exq.enqueue_all(Exq, [
+        ["q1", PerformWorker, [], [schedule: {:in, 1}, unique_for: 60]],
+        ["q1", PerformWorker, [], [schedule: {:in, 1}, unique_for: 60]]
+      ])
 
     assert j1 == j2
 
     :timer.sleep(2000)
     assert_received {:worked}
 
-    [{:ok, _}] = Exq.enqueue_all(Exq, [
-      ["q1", PerformWorker, [], [schedule: {:in, 1}, unique_for: 60]]
-    ])
+    [{:ok, _}] =
+      Exq.enqueue_all(Exq, [
+        ["q1", PerformWorker, [], [schedule: {:in, 1}, unique_for: 60]]
+      ])
+
     :timer.sleep(1500)
     assert_received {:worked}
     stop_process(sup)

--- a/test/fake_mode_test.exs
+++ b/test/fake_mode_test.exs
@@ -51,31 +51,32 @@ defmodule FakeModeTest do
       scheduled_at = DateTime.utc_now()
       assert [] = Exq.Mock.jobs()
 
-      assert [{:ok, _}, {:ok, _}, {:ok, _}] = Exq.enqueue_all(Exq, [
-        ["low", BrokenWorker, [1], []],
-        ["low", BrokenWorker, [2], [schedule: {:at, scheduled_at}]],
-        ["low", BrokenWorker, [3], [schedule: {:in, 300}]]
-      ])
+      assert [{:ok, _}, {:ok, _}, {:ok, _}] =
+               Exq.enqueue_all(Exq, [
+                 ["low", BrokenWorker, [1], []],
+                 ["low", BrokenWorker, [2], [schedule: {:at, scheduled_at}]],
+                 ["low", BrokenWorker, [3], [schedule: {:in, 300}]]
+               ])
 
       assert [
-        %Exq.Support.Job{
-          args: [1],
-          class: FakeModeTest.BrokenWorker,
-          queue: "low"
-        },
-        %Exq.Support.Job{
-          args: [2],
-          class: FakeModeTest.BrokenWorker,
-          queue: "low",
-          enqueued_at: ^scheduled_at
-        },
-        %Exq.Support.Job{
-          args: [3],
-          class: FakeModeTest.BrokenWorker,
-          queue: "low",
-          enqueued_at: scheduled_in
-        }
-      ] = Exq.Mock.jobs()
+               %Exq.Support.Job{
+                 args: [1],
+                 class: FakeModeTest.BrokenWorker,
+                 queue: "low"
+               },
+               %Exq.Support.Job{
+                 args: [2],
+                 class: FakeModeTest.BrokenWorker,
+                 queue: "low",
+                 enqueued_at: ^scheduled_at
+               },
+               %Exq.Support.Job{
+                 args: [3],
+                 class: FakeModeTest.BrokenWorker,
+                 queue: "low",
+                 enqueued_at: scheduled_in
+               }
+             ] = Exq.Mock.jobs()
 
       scheduled_seconds = Time.unix_seconds(scheduled_in)
       current_seconds = Time.unix_seconds(DateTime.utc_now())

--- a/test/fake_mode_test.exs
+++ b/test/fake_mode_test.exs
@@ -47,6 +47,43 @@ defmodule FakeModeTest do
       assert current_seconds + 310 > scheduled_seconds
     end
 
+    test "enqueue_all" do
+      scheduled_at = DateTime.utc_now()
+      assert [] = Exq.Mock.jobs()
+
+      assert [{:ok, _}, {:ok, _}, {:ok, _}] = Exq.enqueue_all(Exq, [
+        ["low", BrokenWorker, [1], []],
+        ["low", BrokenWorker, [2], [schedule: {:at, scheduled_at}]],
+        ["low", BrokenWorker, [3], [schedule: {:in, 300}]]
+      ])
+
+      assert [
+        %Exq.Support.Job{
+          args: [1],
+          class: FakeModeTest.BrokenWorker,
+          queue: "low"
+        },
+        %Exq.Support.Job{
+          args: [2],
+          class: FakeModeTest.BrokenWorker,
+          queue: "low",
+          enqueued_at: ^scheduled_at
+        },
+        %Exq.Support.Job{
+          args: [3],
+          class: FakeModeTest.BrokenWorker,
+          queue: "low",
+          enqueued_at: scheduled_in
+        }
+      ] = Exq.Mock.jobs()
+
+      scheduled_seconds = Time.unix_seconds(scheduled_in)
+      current_seconds = Time.unix_seconds(DateTime.utc_now())
+
+      assert current_seconds + 290 < scheduled_seconds
+      assert current_seconds + 310 > scheduled_seconds
+    end
+
     test "with predetermined job ID" do
       jid = UUID.uuid4()
 

--- a/test/fake_mode_test.exs
+++ b/test/fake_mode_test.exs
@@ -51,7 +51,7 @@ defmodule FakeModeTest do
       scheduled_at = DateTime.utc_now()
       assert [] = Exq.Mock.jobs()
 
-      assert [{:ok, _}, {:ok, _}, {:ok, _}] =
+      assert {:ok, [{:ok, _}, {:ok, _}, {:ok, _}]} =
                Exq.enqueue_all(Exq, [
                  ["low", BrokenWorker, [1], []],
                  ["low", BrokenWorker, [2], [schedule: {:at, scheduled_at}]],

--- a/test/inline_mode_test.exs
+++ b/test/inline_mode_test.exs
@@ -23,6 +23,14 @@ defmodule InlineModeTest do
       assert {:ok, _} = Exq.enqueue_in(Exq, "low", 300, EchoWorker, [1])
     end
 
+    test "enqueue_all should return the correct value" do
+      assert [{:ok, _}, {:ok, _}, {:ok, _}] = Exq.enqueue_all(Exq, [
+        ["low", EchoWorker, [1], [schedule: {:in, 300}]],
+        ["low", EchoWorker, [1], [schedule: {:at, DateTime.utc_now()}]],
+        ["low", EchoWorker, [1], []]
+      ])
+    end
+
     test "enqueue should use the provided job ID, if any" do
       jid = UUID.uuid4()
       assert {:ok, jid} == Exq.enqueue(Exq, "low", EchoWorker, [1], jid: jid)

--- a/test/inline_mode_test.exs
+++ b/test/inline_mode_test.exs
@@ -24,7 +24,7 @@ defmodule InlineModeTest do
     end
 
     test "enqueue_all should return the correct value" do
-      assert [{:ok, _}, {:ok, _}, {:ok, _}] =
+      assert {:ok, [{:ok, _}, {:ok, _}, {:ok, _}]} =
                Exq.enqueue_all(Exq, [
                  ["low", EchoWorker, [1], [schedule: {:in, 300}]],
                  ["low", EchoWorker, [1], [schedule: {:at, DateTime.utc_now()}]],

--- a/test/inline_mode_test.exs
+++ b/test/inline_mode_test.exs
@@ -24,11 +24,12 @@ defmodule InlineModeTest do
     end
 
     test "enqueue_all should return the correct value" do
-      assert [{:ok, _}, {:ok, _}, {:ok, _}] = Exq.enqueue_all(Exq, [
-        ["low", EchoWorker, [1], [schedule: {:in, 300}]],
-        ["low", EchoWorker, [1], [schedule: {:at, DateTime.utc_now()}]],
-        ["low", EchoWorker, [1], []]
-      ])
+      assert [{:ok, _}, {:ok, _}, {:ok, _}] =
+               Exq.enqueue_all(Exq, [
+                 ["low", EchoWorker, [1], [schedule: {:in, 300}]],
+                 ["low", EchoWorker, [1], [schedule: {:at, DateTime.utc_now()}]],
+                 ["low", EchoWorker, [1], []]
+               ])
     end
 
     test "enqueue should use the provided job ID, if any" do


### PR DESCRIPTION
This PR addresses: 
https://github.com/akira/exq/issues/482

API:
```elixir
jobs = [
  [queue_1, time_1, worker_1, args_1, options_1],
  [queue_2, time_2, worker_2, args_2, options_2],
  [queue_3, time_3, worker_3, args_3, options_3]
  ...
]

Exq.Enqueuer.enqueue_all(Exq.Enqueuer, jobs)

# Example returns
# 1.
{:error, reason}

# 2.
[
  {:ok, jid_1},
  {:ok, jid_2},
  {:ok, jid_3}
]

# 3.
[
  {:ok, jid_1},
  {:conflict, jid_2},
  {:conflict, jid_3}
]
```

@ananthakumaran Here is a quick draft, please take a quick look and let me know if I am missing anything obvious, I will get back to polishing, adding tests etc once I get an inital thumbs up.

cheers!