### PR TITLE
Add job_id to Logger metadata for tracing

### DIFF
--- a/lib/exq/worker/server.ex
+++ b/lib/exq/worker/server.ex
@@ -21,6 +21,7 @@ defmodule Exq.Worker.Server do
   alias Exq.Middleware.Server, as: Middleware
   alias Exq.Middleware.Pipeline
   alias Exq.Worker.Metadata
+  require Logger
 
   defmodule State do
     defstruct job_serialized: nil,
@@ -172,6 +173,7 @@ defmodule Exq.Worker.Server do
     {:ok, pid} =
       Task.start_link(fn ->
         :ok = Metadata.associate(metadata, self(), job)
+        Logger.metadata(job_id: job.jid)
         result = apply(worker_module, :perform, job.args)
         GenServer.cast(worker, {:done, result})
       end)


### PR DESCRIPTION
Hi,

I think it would be helpful to add job id to Logger metadata. So it would provide better log tracebility.

For example:
```elixir
config :logger, :console,
  format: "$time $metadata[$level] $message\n",
  metadata: [:job_id]
```
produce log
`13:13:00.120 job_id=8a762129-beff-4a2e-b9f6-35d1a1067581 [info] Time calculate pending orders - 0`

and we can find all log that belongs to the same job

How do you think.