### PR TITLE
Add option to remove unique token

### DIFF
--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -291,13 +291,14 @@ defmodule Exq.Api do
   Expected args:
     * `pid` - Exq.Api process
     * `raw_job` - raw json encoded job value
+    * `unlock` - (boolean) whether to unlock jobs unique tokens, default is `false`
 
   Returns:
     * `:ok`
 
   """
-  def remove_failed_jobs(pid, raw_jobs) do
-    GenServer.call(pid, {:remove_failed_jobs, raw_jobs})
+  def remove_failed_jobs(pid, raw_jobs, unlock \\ false) do
+    GenServer.call(pid, {:remove_failed_jobs, raw_jobs, unlock})
   end
 
   def clear_failed(pid) do

--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -467,13 +467,14 @@ defmodule Exq.Api do
   Expected args:
     * `pid` - Exq.Api process
     * `raw_jobs` - list of raw json encoded job values
+    * `unlock` - (boolean) whether to unlock jobs unique tokens, default is `false`
 
   Returns:
     * `:ok`
 
   """
-  def remove_scheduled_jobs(pid, raw_jobs) do
-    GenServer.call(pid, {:remove_scheduled_jobs, raw_jobs})
+  def remove_scheduled_jobs(pid, raw_jobs, unlock \\ false) do
+    GenServer.call(pid, {:remove_scheduled_jobs, raw_jobs, unlock})
   end
 
   def clear_scheduled(pid) do

--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -189,14 +189,15 @@ defmodule Exq.Api do
     * `pid` - Exq.Api process
     * `queue` - The name of the queue to remove the job from
     * `raw_jobs` - list of raw json encoded job values
-    * `unlock` - (boolean) whether to unlock jobs unique tokens, default is `false`
+    * `options`
+      - clear_unique_tokens: (boolean) whether to clear jobs unique tokens, default is `false`
 
   Returns:
     * `:ok`
 
   """
-  def remove_enqueued_jobs(pid, queue, raw_jobs, unlock \\ false) do
-    GenServer.call(pid, {:remove_enqueued_jobs, queue, raw_jobs, unlock})
+  def remove_enqueued_jobs(pid, queue, raw_jobs, options \\ []) do
+    GenServer.call(pid, {:remove_enqueued_jobs, queue, raw_jobs, options})
   end
 
   @doc """
@@ -291,14 +292,15 @@ defmodule Exq.Api do
   Expected args:
     * `pid` - Exq.Api process
     * `raw_jobs` - list of raw json encoded job values
-    * `unlock` - (boolean) whether to unlock jobs unique tokens, default is `false`
+    * `options`
+      - clear_unique_tokens: (boolean) whether to clear jobs unique tokens, default is `false`
 
   Returns:
     * `:ok`
 
   """
-  def remove_failed_jobs(pid, raw_jobs, unlock \\ false) do
-    GenServer.call(pid, {:remove_failed_jobs, raw_jobs, unlock})
+  def remove_failed_jobs(pid, raw_jobs, options \\ []) do
+    GenServer.call(pid, {:remove_failed_jobs, raw_jobs, options})
   end
 
   def clear_failed(pid) do
@@ -379,14 +381,15 @@ defmodule Exq.Api do
   Expected args:
     * `pid` - Exq.Api process
     * `raw_jobs` - list of raw json encoded job values
-    * `unlock` - (boolean) whether to unlock jobs unique tokens, default is `false`
+    * `options`
+      - clear_unique_tokens: (boolean) whether to clear jobs unique tokens, default is `false`
 
   Returns:
     * `:ok`
 
   """
-  def remove_retry_jobs(pid, raw_jobs, unlock \\ false) do
-    GenServer.call(pid, {:remove_retry_jobs, raw_jobs, unlock})
+  def remove_retry_jobs(pid, raw_jobs, options \\ []) do
+    GenServer.call(pid, {:remove_retry_jobs, raw_jobs, options})
   end
 
   def clear_retries(pid) do
@@ -467,14 +470,15 @@ defmodule Exq.Api do
   Expected args:
     * `pid` - Exq.Api process
     * `raw_jobs` - list of raw json encoded job values
-    * `unlock` - (boolean) whether to unlock jobs unique tokens, default is `false`
+    * `options`
+      - clear_unique_tokens: (boolean) whether to clear jobs unique tokens, default is `false`
 
   Returns:
     * `:ok`
 
   """
-  def remove_scheduled_jobs(pid, raw_jobs, unlock \\ false) do
-    GenServer.call(pid, {:remove_scheduled_jobs, raw_jobs, unlock})
+  def remove_scheduled_jobs(pid, raw_jobs, options \\ []) do
+    GenServer.call(pid, {:remove_scheduled_jobs, raw_jobs, options})
   end
 
   def clear_scheduled(pid) do

--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -290,7 +290,7 @@ defmodule Exq.Api do
 
   Expected args:
     * `pid` - Exq.Api process
-    * `raw_job` - raw json encoded job value
+    * `raw_jobs` - list of raw json encoded job values
     * `unlock` - (boolean) whether to unlock jobs unique tokens, default is `false`
 
   Returns:
@@ -310,7 +310,7 @@ defmodule Exq.Api do
 
   Expected args:
     * `pid` - Exq.Api process
-    * `raw_job` - raw json encoded job value
+    * `raw_jobs` - list of raw json encoded job values
 
   Returns:
     * `{:ok, num_enqueued}`
@@ -378,14 +378,15 @@ defmodule Exq.Api do
 
   Expected args:
     * `pid` - Exq.Api process
-    * `raw_job` - raw json encoded job value
+    * `raw_jobs` - list of raw json encoded job values
+    * `unlock` - (boolean) whether to unlock jobs unique tokens, default is `false`
 
   Returns:
     * `:ok`
 
   """
-  def remove_retry_jobs(pid, raw_jobs) do
-    GenServer.call(pid, {:remove_retry_jobs, raw_jobs})
+  def remove_retry_jobs(pid, raw_jobs, unlock \\ false) do
+    GenServer.call(pid, {:remove_retry_jobs, raw_jobs, unlock})
   end
 
   def clear_retries(pid) do
@@ -397,7 +398,7 @@ defmodule Exq.Api do
 
   Expected args:
     * `pid` - Exq.Api process
-    * `raw_job` - raw json encoded job value
+    * `raw_jobs` - list of raw json encoded job values
 
   Returns:
     * `{:ok, num_enqueued}`
@@ -465,7 +466,7 @@ defmodule Exq.Api do
 
   Expected args:
     * `pid` - Exq.Api process
-    * `raw_job` - raw json encoded job value
+    * `raw_jobs` - list of raw json encoded job values
 
   Returns:
     * `:ok`
@@ -484,7 +485,7 @@ defmodule Exq.Api do
 
   Expected args:
     * `pid` - Exq.Api process
-    * `raw_job` - raw json encoded job value
+    * `raw_jobs` - list of raw json encoded job values
 
   Returns:
     * `{:ok, num_enqueued}`

--- a/lib/exq/api.ex
+++ b/lib/exq/api.ex
@@ -188,14 +188,15 @@ defmodule Exq.Api do
   Expected args:
     * `pid` - Exq.Api process
     * `queue` - The name of the queue to remove the job from
-    * `raw_job` - raw json encoded job value
+    * `raw_jobs` - list of raw json encoded job values
+    * `unlock` - (boolean) whether to unlock jobs unique tokens, default is `false`
 
   Returns:
     * `:ok`
 
   """
-  def remove_enqueued_jobs(pid, queue, raw_jobs) do
-    GenServer.call(pid, {:remove_enqueued_jobs, queue, raw_jobs})
+  def remove_enqueued_jobs(pid, queue, raw_jobs, unlock \\ false) do
+    GenServer.call(pid, {:remove_enqueued_jobs, queue, raw_jobs, unlock})
   end
 
   @doc """

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -157,6 +157,7 @@ defmodule Exq.Api.Server do
 
   def handle_call({:remove_enqueued_jobs, queue, raw_jobs, options}, _from, state) do
     JobQueue.remove_enqueued_jobs(state.redis, state.namespace, queue, raw_jobs)
+
     if Keyword.get(options, :clear_unique_tokens, false) do
       JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
     end
@@ -171,6 +172,7 @@ defmodule Exq.Api.Server do
 
   def handle_call({:remove_retry_jobs, raw_jobs, options}, _from, state) do
     JobQueue.remove_retry_jobs(state.redis, state.namespace, raw_jobs)
+
     if Keyword.get(options, :clear_unique_tokens, false) do
       JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
     end
@@ -190,6 +192,7 @@ defmodule Exq.Api.Server do
 
   def handle_call({:remove_scheduled_jobs, raw_jobs, options}, _from, state) do
     JobQueue.remove_scheduled_jobs(state.redis, state.namespace, raw_jobs)
+
     if Keyword.get(options, :clear_unique_tokens, false) do
       JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
     end
@@ -209,6 +212,7 @@ defmodule Exq.Api.Server do
 
   def handle_call({:remove_failed_jobs, raw_jobs, options}, _from, state) do
     JobQueue.remove_failed_jobs(state.redis, state.namespace, raw_jobs)
+
     if Keyword.get(options, :clear_unique_tokens, false) do
       JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
     end

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -183,8 +183,10 @@ defmodule Exq.Api.Server do
     {:reply, :ok, state}
   end
 
-  def handle_call({:remove_scheduled_jobs, raw_jobs}, _from, state) do
+  def handle_call({:remove_scheduled_jobs, raw_jobs, unlock}, _from, state) do
     JobQueue.remove_scheduled_jobs(state.redis, state.namespace, raw_jobs)
+    if unlock, do: JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
+
     {:reply, :ok, state}
   end
 

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -167,8 +167,9 @@ defmodule Exq.Api.Server do
     {:reply, :ok, state}
   end
 
-  def handle_call({:remove_retry_jobs, raw_jobs}, _from, state) do
+  def handle_call({:remove_retry_jobs, raw_jobs, unlock}, _from, state) do
     JobQueue.remove_retry_jobs(state.redis, state.namespace, raw_jobs)
+    if unlock, do: JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
     {:reply, :ok, state}
   end
 

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -197,8 +197,10 @@ defmodule Exq.Api.Server do
     {:reply, :ok, state}
   end
 
-  def handle_call({:remove_failed_jobs, raw_jobs}, _from, state) do
+  def handle_call({:remove_failed_jobs, raw_jobs, unlock}, _from, state) do
     JobQueue.remove_failed_jobs(state.redis, state.namespace, raw_jobs)
+    if unlock, do: JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
+
     {:reply, :ok, state}
   end
 

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -155,8 +155,10 @@ defmodule Exq.Api.Server do
     {:reply, :ok, state}
   end
 
-  def handle_call({:remove_enqueued_jobs, queue, raw_jobs}, _from, state) do
+  def handle_call({:remove_enqueued_jobs, queue, raw_jobs, unlock}, _from, state) do
     JobQueue.remove_enqueued_jobs(state.redis, state.namespace, queue, raw_jobs)
+    if unlock, do: JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
+
     {:reply, :ok, state}
   end
 

--- a/lib/exq/api/server.ex
+++ b/lib/exq/api/server.ex
@@ -155,9 +155,11 @@ defmodule Exq.Api.Server do
     {:reply, :ok, state}
   end
 
-  def handle_call({:remove_enqueued_jobs, queue, raw_jobs, unlock}, _from, state) do
+  def handle_call({:remove_enqueued_jobs, queue, raw_jobs, options}, _from, state) do
     JobQueue.remove_enqueued_jobs(state.redis, state.namespace, queue, raw_jobs)
-    if unlock, do: JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
+    if Keyword.get(options, :clear_unique_tokens, false) do
+      JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
+    end
 
     {:reply, :ok, state}
   end
@@ -167,9 +169,12 @@ defmodule Exq.Api.Server do
     {:reply, :ok, state}
   end
 
-  def handle_call({:remove_retry_jobs, raw_jobs, unlock}, _from, state) do
+  def handle_call({:remove_retry_jobs, raw_jobs, options}, _from, state) do
     JobQueue.remove_retry_jobs(state.redis, state.namespace, raw_jobs)
-    if unlock, do: JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
+    if Keyword.get(options, :clear_unique_tokens, false) do
+      JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
+    end
+
     {:reply, :ok, state}
   end
 
@@ -183,9 +188,11 @@ defmodule Exq.Api.Server do
     {:reply, :ok, state}
   end
 
-  def handle_call({:remove_scheduled_jobs, raw_jobs, unlock}, _from, state) do
+  def handle_call({:remove_scheduled_jobs, raw_jobs, options}, _from, state) do
     JobQueue.remove_scheduled_jobs(state.redis, state.namespace, raw_jobs)
-    if unlock, do: JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
+    if Keyword.get(options, :clear_unique_tokens, false) do
+      JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
+    end
 
     {:reply, :ok, state}
   end
@@ -200,9 +207,11 @@ defmodule Exq.Api.Server do
     {:reply, :ok, state}
   end
 
-  def handle_call({:remove_failed_jobs, raw_jobs, unlock}, _from, state) do
+  def handle_call({:remove_failed_jobs, raw_jobs, options}, _from, state) do
     JobQueue.remove_failed_jobs(state.redis, state.namespace, raw_jobs)
-    if unlock, do: JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
+    if Keyword.get(options, :clear_unique_tokens, false) do
+      JobQueue.unlock_jobs(state.redis, state.namespace, raw_jobs)
+    end
 
     {:reply, :ok, state}
   end

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -58,7 +58,10 @@ defmodule Exq.Redis.JobQueue do
   end
 
   def unlock_jobs(redis, namespace, raw_jobs) do
-    raw_jobs |> Enum.each(&unlock(redis, namespace, Job.decode(&1).unique_token))
+    for job <- raw_jobs,
+        unique_token = Job.decode(job).unique_token do
+      unlock(redis, namespace, unique_token)
+    end
   end
 
   def unlock(redis, namespace, unique_token) do

--- a/lib/exq/redis/job_queue.ex
+++ b/lib/exq/redis/job_queue.ex
@@ -57,6 +57,10 @@ defmodule Exq.Redis.JobQueue do
     end
   end
 
+  def unlock_jobs(redis, namespace, raw_jobs) do
+    raw_jobs |> Enum.each(&unlock(redis, namespace, Job.decode(&1).unique_token))
+  end
+
   def unlock(redis, namespace, unique_token) do
     Connection.del!(redis, unique_key(namespace, unique_token), retry_on_connection_error: 3)
   end

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -243,17 +243,17 @@ defmodule ApiTest do
     assert {:ok, 0} = Exq.Api.queue_size(Exq.Api, "custom")
   end
 
-  test "remove enqueued jobs but keep lock" do
+  test "remove enqueued jobs but keep unique tokens" do
     {:ok, jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom", raw: true)
     :ok = Exq.Api.remove_enqueued_jobs(Exq.Api, "custom", [job])
     assert {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
-  test "remove and unlock enqueued jobs" do
+  test "remove enqueued jobs and clear their unique tokens" do
     {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom", raw: true)
-    :ok = Exq.Api.remove_enqueued_jobs(Exq.Api, "custom", [job], true)
+    :ok = Exq.Api.remove_enqueued_jobs(Exq.Api, "custom", [job], clear_unique_tokens: true)
     assert {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
@@ -272,16 +272,16 @@ defmodule ApiTest do
     assert {:ok, nil} = Exq.Api.find_scheduled(Exq.Api, jid)
   end
 
-  test "remove and unlock jobs in retry queue" do
+  test "remove jobs in retry queue and clear their unique tokens" do
     {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom")
     JobQueue.retry_job(:testredis, 'test', job, 1, "this is an error")
     {:ok, [raw_job]} = Exq.Api.retries(Exq.Api, raw: true)
-    :ok = Exq.Api.remove_retry_jobs(Exq.Api, [raw_job], true)
+    :ok = Exq.Api.remove_retry_jobs(Exq.Api, [raw_job], clear_unique_tokens: true)
     assert {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
-  test "remove jobs in retry queue but keep lock" do
+  test "remove jobs in retry queue but keep unique tokens" do
     {:ok, jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom")
     JobQueue.retry_job(:testredis, 'test', job, 1, "this is an error")
@@ -321,7 +321,7 @@ defmodule ApiTest do
     assert {:ok, nil} = Exq.Api.find_scheduled(Exq.Api, jid)
   end
 
-  test "remove scheduled jobs but keep lock" do
+  test "remove scheduled jobs but keep unique tokens" do
     {:ok, jid} = Exq.enqueue_in(Exq, "custom", 1000, Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.scheduled(Exq.Api, raw: true)
     :ok = Exq.Api.remove_scheduled_jobs(Exq.Api, [job])
@@ -329,10 +329,10 @@ defmodule ApiTest do
     assert {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
-  test "remove and unlock scheduled jobs" do
+  test "remove scheduled jobs and clear their unique tokens" do
     {:ok, _} = Exq.enqueue_in(Exq, "custom", 1000, Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.scheduled(Exq.Api, raw: true)
-    :ok = Exq.Api.remove_scheduled_jobs(Exq.Api, [job], true)
+    :ok = Exq.Api.remove_scheduled_jobs(Exq.Api, [job], clear_unique_tokens: true)
     {:ok, []} = Exq.Api.scheduled(Exq.Api, raw: true)
     assert {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
@@ -359,16 +359,16 @@ defmodule ApiTest do
     {:ok, nil} = Exq.Api.find_failed(Exq.Api, "1234")
   end
 
-  test "remove and unlock jobs in failed queue" do
+  test "remove jobs in failed queue and clear their unique tokens" do
     {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom")
     JobQueue.fail_job(:testredis, 'test', job, "this is an error")
     {:ok, [raw_job]} = Exq.Api.failed(Exq.Api, raw: true)
-    :ok = Exq.Api.remove_failed_jobs(Exq.Api, [raw_job], true)
+    :ok = Exq.Api.remove_failed_jobs(Exq.Api, [raw_job], clear_unique_tokens: true)
     assert {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
-  test "remove jobs in failed queue but keep lock" do
+  test "remove jobs in failed queue but keep unique tokens" do
     {:ok, jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom")
     JobQueue.fail_job(:testredis, 'test', job, "this is an error")

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -247,16 +247,14 @@ defmodule ApiTest do
     {:ok, jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom", raw: true)
     :ok = Exq.Api.remove_enqueued_jobs(Exq.Api, "custom", [job])
-    assert {:ok, 0} = Exq.Api.queue_size(Exq.Api, "custom")
-    {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
+    assert {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
   test "remove and unlock enqueued jobs" do
     {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom", raw: true)
     :ok = Exq.Api.remove_enqueued_jobs(Exq.Api, "custom", [job], true)
-    assert {:ok, 0} = Exq.Api.queue_size(Exq.Api, "custom")
-    {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
+    assert {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
   test "remove job in retry queue" do
@@ -275,21 +273,21 @@ defmodule ApiTest do
   end
 
   test "remove and unlock jobs in retry queue" do
-    {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
+    {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom")
     JobQueue.retry_job(:testredis, 'test', job, 1, "this is an error")
     {:ok, [raw_job]} = Exq.Api.retries(Exq.Api, raw: true)
-    Exq.Api.remove_retry_jobs(Exq.Api, [raw_job], true)
-    {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
+    :ok = Exq.Api.remove_retry_jobs(Exq.Api, [raw_job], true)
+    assert {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
   test "remove jobs in retry queue but keep lock" do
-    {:ok, jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
+    {:ok, jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom")
     JobQueue.retry_job(:testredis, 'test', job, 1, "this is an error")
     {:ok, [raw_job]} = Exq.Api.retries(Exq.Api, raw: true)
-    Exq.Api.remove_retry_jobs(Exq.Api, [raw_job])
-    {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
+    :ok = Exq.Api.remove_retry_jobs(Exq.Api, [raw_job])
+    assert {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
   test "re enqueue jobs in retry queue" do
@@ -327,16 +325,16 @@ defmodule ApiTest do
     {:ok, jid} = Exq.enqueue_in(Exq, "custom", 1000, Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.scheduled(Exq.Api, raw: true)
     :ok = Exq.Api.remove_scheduled_jobs(Exq.Api, [job])
-    assert {:ok, []} = Exq.Api.scheduled(Exq.Api, raw: true)
-    {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
+    {:ok, []} = Exq.Api.scheduled(Exq.Api, raw: true)
+    assert {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
   test "remove and unlock scheduled jobs" do
     {:ok, _} = Exq.enqueue_in(Exq, "custom", 1000, Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.scheduled(Exq.Api, raw: true)
     :ok = Exq.Api.remove_scheduled_jobs(Exq.Api, [job], true)
-    assert {:ok, []} = Exq.Api.scheduled(Exq.Api, raw: true)
-    {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
+    {:ok, []} = Exq.Api.scheduled(Exq.Api, raw: true)
+    assert {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
   test "enqueue jobs in scheduled queue" do
@@ -362,21 +360,21 @@ defmodule ApiTest do
   end
 
   test "remove and unlock jobs in failed queue" do
-    {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
+    {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom")
     JobQueue.fail_job(:testredis, 'test', job, "this is an error")
     {:ok, [raw_job]} = Exq.Api.failed(Exq.Api, raw: true)
-    Exq.Api.remove_failed_jobs(Exq.Api, [raw_job], true)
-    {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
+    :ok = Exq.Api.remove_failed_jobs(Exq.Api, [raw_job], true)
+    assert {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
   test "remove jobs in failed queue but keep lock" do
-    {:ok, jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
+    {:ok, jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom")
     JobQueue.fail_job(:testredis, 'test', job, "this is an error")
     {:ok, [raw_job]} = Exq.Api.failed(Exq.Api, raw: true)
-    Exq.Api.remove_failed_jobs(Exq.Api, [raw_job])
-    {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
+    :ok = Exq.Api.remove_failed_jobs(Exq.Api, [raw_job])
+    assert {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
   test "enqueue jobs in failed queue" do

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -247,7 +247,9 @@ defmodule ApiTest do
     {:ok, jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom", raw: true)
     :ok = Exq.Api.remove_enqueued_jobs(Exq.Api, "custom", [job])
-    assert {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
+
+    assert {:conflict, ^jid} =
+             Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
   test "remove enqueued jobs and clear their unique tokens" do
@@ -287,7 +289,9 @@ defmodule ApiTest do
     JobQueue.retry_job(:testredis, 'test', job, 1, "this is an error")
     {:ok, [raw_job]} = Exq.Api.retries(Exq.Api, raw: true)
     :ok = Exq.Api.remove_retry_jobs(Exq.Api, [raw_job])
-    assert {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
+
+    assert {:conflict, ^jid} =
+             Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
   test "re enqueue jobs in retry queue" do
@@ -322,11 +326,15 @@ defmodule ApiTest do
   end
 
   test "remove scheduled jobs but keep unique tokens" do
-    {:ok, jid} = Exq.enqueue_in(Exq, "custom", 1000, Bogus, [], unique_for: 60, unique_token: "t1")
+    {:ok, jid} =
+      Exq.enqueue_in(Exq, "custom", 1000, Bogus, [], unique_for: 60, unique_token: "t1")
+
     {:ok, [job]} = Exq.Api.scheduled(Exq.Api, raw: true)
     :ok = Exq.Api.remove_scheduled_jobs(Exq.Api, [job])
     {:ok, []} = Exq.Api.scheduled(Exq.Api, raw: true)
-    assert {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
+
+    assert {:conflict, ^jid} =
+             Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
   test "remove scheduled jobs and clear their unique tokens" do
@@ -374,7 +382,9 @@ defmodule ApiTest do
     JobQueue.fail_job(:testredis, 'test', job, "this is an error")
     {:ok, [raw_job]} = Exq.Api.failed(Exq.Api, raw: true)
     :ok = Exq.Api.remove_failed_jobs(Exq.Api, [raw_job])
-    assert {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
+
+    assert {:conflict, ^jid} =
+             Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
   test "enqueue jobs in failed queue" do

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -244,11 +244,11 @@ defmodule ApiTest do
   end
 
   test "remove enqueued jobs but keep lock" do
-    {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
+    {:ok, jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
     {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom", raw: true)
     :ok = Exq.Api.remove_enqueued_jobs(Exq.Api, "custom", [job])
     assert {:ok, 0} = Exq.Api.queue_size(Exq.Api, "custom")
-    {:conflict, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
+    {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
   test "remove and unlock enqueued jobs" do
@@ -272,6 +272,24 @@ defmodule ApiTest do
     {:ok, [raw_job]} = Exq.Api.retries(Exq.Api, raw: true)
     Exq.Api.remove_retry_jobs(Exq.Api, [raw_job])
     assert {:ok, nil} = Exq.Api.find_scheduled(Exq.Api, jid)
+  end
+
+  test "remove and unlock jobs in retry queue" do
+    {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
+    {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom")
+    JobQueue.retry_job(:testredis, 'test', job, 1, "this is an error")
+    {:ok, [raw_job]} = Exq.Api.retries(Exq.Api, raw: true)
+    Exq.Api.remove_retry_jobs(Exq.Api, [raw_job], true)
+    {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
+  end
+
+  test "remove jobs in retry queue but keep lock" do
+    {:ok, jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
+    {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom")
+    JobQueue.retry_job(:testredis, 'test', job, 1, "this is an error")
+    {:ok, [raw_job]} = Exq.Api.retries(Exq.Api, raw: true)
+    Exq.Api.remove_retry_jobs(Exq.Api, [raw_job])
+    {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
   end
 
   test "re enqueue jobs in retry queue" do
@@ -336,13 +354,13 @@ defmodule ApiTest do
     {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
   end
 
-  test "remove jobs but keep lock in failed queue" do
-    {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
+  test "remove jobs in failed queue but keep lock" do
+    {:ok, jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
     {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom")
     JobQueue.fail_job(:testredis, 'test', job, "this is an error")
     {:ok, [raw_job]} = Exq.Api.failed(Exq.Api, raw: true)
     Exq.Api.remove_failed_jobs(Exq.Api, [raw_job])
-    {:conflict, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
+    {:conflict, ^jid} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 600, unique_token: "t1")
   end
 
   test "enqueue jobs in failed queue" do

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -254,8 +254,10 @@ defmodule ApiTest do
 
   test "remove enqueued jobs and clear their unique tokens" do
     {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
-    {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom", raw: true)
-    :ok = Exq.Api.remove_enqueued_jobs(Exq.Api, "custom", [job], clear_unique_tokens: true)
+    {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [])
+    {:ok, [_j1, _j2] = raw_jobs} = Exq.Api.jobs(Exq.Api, "custom", raw: true)
+    :ok = Exq.Api.remove_enqueued_jobs(Exq.Api, "custom", raw_jobs, clear_unique_tokens: true)
+    assert {:ok, []} = Exq.Api.jobs(Exq.Api, "custom", raw: true)
     assert {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
@@ -276,10 +278,13 @@ defmodule ApiTest do
 
   test "remove jobs in retry queue and clear their unique tokens" do
     {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
-    {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom")
-    JobQueue.retry_job(:testredis, 'test', job, 1, "this is an error")
-    {:ok, [raw_job]} = Exq.Api.retries(Exq.Api, raw: true)
-    :ok = Exq.Api.remove_retry_jobs(Exq.Api, [raw_job], clear_unique_tokens: true)
+    {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [])
+    {:ok, [job1, job2]} = Exq.Api.jobs(Exq.Api, "custom")
+    JobQueue.retry_job(:testredis, 'test', job1, 1, "this is an error")
+    JobQueue.retry_job(:testredis, 'test', job2, 1, "this is an another error")
+    {:ok, [_j1, _j2] = raw_jobs} = Exq.Api.retries(Exq.Api, raw: true)
+    :ok = Exq.Api.remove_retry_jobs(Exq.Api, raw_jobs, clear_unique_tokens: true)
+    assert {:ok, []} = Exq.Api.retries(Exq.Api, raw: true)
     assert {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
@@ -339,9 +344,10 @@ defmodule ApiTest do
 
   test "remove scheduled jobs and clear their unique tokens" do
     {:ok, _} = Exq.enqueue_in(Exq, "custom", 1000, Bogus, [], unique_for: 60, unique_token: "t1")
-    {:ok, [job]} = Exq.Api.scheduled(Exq.Api, raw: true)
-    :ok = Exq.Api.remove_scheduled_jobs(Exq.Api, [job], clear_unique_tokens: true)
-    {:ok, []} = Exq.Api.scheduled(Exq.Api, raw: true)
+    {:ok, _} = Exq.enqueue_in(Exq, "custom", 1000, Bogus, [])
+    {:ok, [_j1, _j2] = raw_jobs} = Exq.Api.scheduled(Exq.Api, raw: true)
+    :ok = Exq.Api.remove_scheduled_jobs(Exq.Api, raw_jobs, clear_unique_tokens: true)
+    assert {:ok, []} = Exq.Api.scheduled(Exq.Api, raw: true)
     assert {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 
@@ -369,10 +375,13 @@ defmodule ApiTest do
 
   test "remove jobs in failed queue and clear their unique tokens" do
     {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
-    {:ok, [job]} = Exq.Api.jobs(Exq.Api, "custom")
-    JobQueue.fail_job(:testredis, 'test', job, "this is an error")
-    {:ok, [raw_job]} = Exq.Api.failed(Exq.Api, raw: true)
-    :ok = Exq.Api.remove_failed_jobs(Exq.Api, [raw_job], clear_unique_tokens: true)
+    {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [])
+    {:ok, [job1, job2]} = Exq.Api.jobs(Exq.Api, "custom")
+    JobQueue.fail_job(:testredis, 'test', job1, "this is an error")
+    JobQueue.fail_job(:testredis, 'test', job2, "this is an another error")
+    {:ok, [_j1, _j2] = raw_jobs} = Exq.Api.failed(Exq.Api, raw: true)
+    :ok = Exq.Api.remove_failed_jobs(Exq.Api, raw_jobs, clear_unique_tokens: true)
+    assert {:ok, []} = Exq.Api.failed(Exq.Api, raw: true)
     assert {:ok, _} = Exq.enqueue(Exq, "custom", Bogus, [], unique_for: 60, unique_token: "t1")
   end
 


### PR DESCRIPTION
According to [this issue](https://github.com/akira/exq/issues/494) Addition of `unlock` option to `remove_*_jobs` functions family