### PR TITLE
Add ability to snooze job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
             otp: 27
             check_warnings: true
             check_format: true
+            coveralls: true
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -92,6 +93,14 @@ jobs:
 
     - name: Run unit tests
       run: mix coveralls.github --no-start
+      if: ${{ matrix.coveralls }}
       env:
         MIX_ENV: test
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Run unit tests
+      run: mix test --no-start
+      if: ${{ ! matrix.coveralls }}
+      env:
+        MIX_ENV: test
+

--- a/README.md
+++ b/README.md
@@ -554,6 +554,20 @@ Exq comes with an `enqueue_all` method which guarantees atomicity.
 ])
 ```
 
+## Snooze
+
+A Job can be snoozed by returning `{:snooze, time_to_sleep_in_seconds}`
+from perform method. By default this feature is not enabled. Add
+`Exq.Middleware.Snooze` to the middleware list to enable this feature.
+
+```elixir
+defmodule MyWorker do
+  def perform do
+    {:snooze, 10}
+  end
+end
+```
+
 ## Web UI
 
 Exq has a separate repo, exq_ui which provides with a Web UI to monitor your workers:

--- a/config/test.exs
+++ b/config/test.exs
@@ -27,6 +27,7 @@ config :exq,
     Exq.Middleware.Job,
     Exq.Middleware.Manager,
     Exq.Middleware.Unique,
-    Exq.Middleware.Telemetry
+    Exq.Middleware.Telemetry,
+    Exq.Middleware.Snooze
   ],
   queue_adapter: Exq.Adapters.Queue.Mock

--- a/lib/exq/middleware/pipeline.ex
+++ b/lib/exq/middleware/pipeline.ex
@@ -47,7 +47,7 @@ defmodule Exq.Middleware.Pipeline do
   end
 
   @doc """
-  Sets `terminated` to true
+  Sets `terminated` to true
   """
   def terminate(%Pipeline{} = pipeline) do
     %{pipeline | terminated: true}

--- a/lib/exq/middleware/snooze.ex
+++ b/lib/exq/middleware/snooze.ex
@@ -1,0 +1,34 @@
+defmodule Exq.Middleware.Snooze do
+  @behaviour Exq.Middleware.Behaviour
+  alias Exq.Redis.JobQueue
+  alias Exq.Middleware.Pipeline
+
+  def before_work(pipeline) do
+    pipeline
+  end
+
+  def after_processed_work(
+        %Pipeline{assigns: %{result: {:snooze, seconds}} = assigns} =
+          pipeline
+      )
+      when is_number(seconds) do
+    if assigns.job do
+      JobQueue.snooze_job(
+        assigns.redis,
+        assigns.namespace,
+        assigns.job,
+        seconds
+      )
+    end
+
+    pipeline
+  end
+
+  def after_processed_work(pipeline) do
+    pipeline
+  end
+
+  def after_failed_work(pipeline) do
+    pipeline
+  end
+end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -315,7 +315,8 @@ defmodule Exq.ConfigTest do
              Exq.Middleware.Job,
              Exq.Middleware.Manager,
              Exq.Middleware.Unique,
-             Exq.Middleware.Telemetry
+             Exq.Middleware.Telemetry,
+             Exq.Middleware.Snooze
            ]
 
     assert mode == :default

--- a/test/job_queue_test.exs
+++ b/test/job_queue_test.exs
@@ -171,6 +171,37 @@ defmodule JobQueueTest do
     end)
   end
 
+  test "snooze job" do
+    with_application_env(:exq, :max_retries, 1, fn ->
+      JobQueue.snooze_job(
+        :testredis,
+        "test",
+        %{
+          retry_count: 0,
+          retry: true,
+          queue: "default",
+          class: "MyWorker",
+          jid: UUID.uuid4(),
+          error_class: nil,
+          error_message: "failed",
+          retried_at: Time.unix_seconds(),
+          failed_at: Time.unix_seconds(),
+          enqueued_at: Time.unix_seconds(),
+          finished_at: nil,
+          processor: nil,
+          args: [],
+          unique_for: nil,
+          unique_until: nil,
+          unique_token: nil,
+          unlocks_at: nil
+        },
+        10
+      )
+
+      assert JobQueue.queue_size(:testredis, "test", :retry) == 1
+    end)
+  end
+
   test "scheduler_dequeue max_score" do
     add_usecs = fn time, offset ->
       base = time |> DateTime.to_unix(:microsecond)

--- a/test/middleware_test.exs
+++ b/test/middleware_test.exs
@@ -240,7 +240,8 @@ defmodule MiddlewareTest do
       Exq.Middleware.Job,
       Exq.Middleware.Manager,
       Exq.Middleware.Unique,
-      Exq.Middleware.Telemetry
+      Exq.Middleware.Telemetry,
+      Exq.Middleware.Snooze
     ]
 
     assert Middleware.all(Middleware) == chain


### PR DESCRIPTION
Implementation is same as how retry is implemented, just that retry_count is not incremented, so a job can be snoozed unlimited times