### PR TITLE
Fix shutdown order of worker and enqueuer

### DIFF
--- a/lib/exq/support/mode.ex
+++ b/lib/exq/support/mode.ex
@@ -31,10 +31,10 @@ defmodule Exq.Support.Mode do
       worker(Exq.Middleware.Server, [opts]),
       worker(Exq.Stats.Server, [opts]),
       worker(Exq.Node.Server, [opts]),
+      worker(Exq.Enqueuer.Server, [opts]),
       supervisor(Exq.Worker.Supervisor, [opts]),
       worker(Exq.Manager.Server, [opts]),
       worker(Exq.WorkerDrainer.Server, [opts], shutdown: shutdown_timeout),
-      worker(Exq.Enqueuer.Server, [opts]),
       worker(Exq.Api.Server, [opts])
     ]
 


### PR DESCRIPTION
Enqueuer should be started before worker and shutdown after worker, as worker drainer might keep the worker process alive for `shutdown_timeout` and during that period, any enqueue operation inside the worker process will fail