### PR TITLE
Fix Protocol.UndefinedError

### DIFF
--- a/lib/exq/redis/job_stat.ex
+++ b/lib/exq/redis/job_stat.ex
@@ -101,7 +101,7 @@ defmodule Exq.Redis.JobStat do
       error ->
         Logger.error("Failed to send node stats. Unexpected error from redis: #{inspect(error)}")
 
-        nil
+        []
     end
   end
 


### PR DESCRIPTION
`Exq.Redis.JobStat.node_ping/3` returns nil when Redis returns an unexpected response, but `Exq.Node.Server.process_signals/2` doesn't handle nil and crashes when calling `Enum.each(nil, ...)`.